### PR TITLE
add field content structs

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,4 +1,5 @@
 # Used by "mix format"
 [
-  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"],
+  import_deps: [:typed_struct]
 ]

--- a/lib/structs/field_content.ex
+++ b/lib/structs/field_content.ex
@@ -1,0 +1,120 @@
+defmodule ExPass.Structs.FieldContent do
+  @moduledoc """
+  Represents a field on a pass.
+
+  A field displays information on the front or back of a pass, such as a customer's name,
+  a balance, or an expiration date.
+
+  ## Attributes
+
+  - `attributed_value`: The field's value, which can include HTML markup for enhanced
+    formatting or interactivity. It can be a string, number, or ISO 8601 date string.
+
+  ## Examples
+
+      iex> field = ExPass.Structs.FieldContent.new(%{attributed_value: "<a href='http://example.com'>Click here</a>"})
+      %ExPass.Structs.FieldContent{attributed_value: "<a href='http://example.com'>Click here</a>"}
+
+      iex> field = ExPass.Structs.FieldContent.new(%{attributed_value: 42})
+      %ExPass.Structs.FieldContent{attributed_value: 42}
+
+      iex> field = ExPass.Structs.FieldContent.new(%{attributed_value: "2023-04-15T14:30:00Z"})
+      %ExPass.Structs.FieldContent{attributed_value: "2023-04-15T14:30:00Z"}
+  """
+
+  use TypedStruct
+  alias ExPass.Utils.Validators
+
+  @typedoc """
+  The field's attributed value, which may include HTML markup for enhanced
+  formatting or interactivity.
+
+  Optional. The attributed value of the field, which can be:
+
+  - A localizable string (e.g., "Welcome to our service")
+  - An ISO 8601 date string (e.g., "2023-04-15T14:30:00Z")
+  - A number (e.g., 42)
+
+  When both attributed_value and value are present, attribute_value takes
+  priority. It supports a limited set of HTML tags,
+  primarily for basic text formatting and creating hyperlinks. This allows
+  for more dynamic content presentation,
+  such as clickable links or emphasized text.
+
+  Note that only a subset of HTML tags are supported, generally restricted
+  to simple text formatting and anchor elements.
+  Unsupported tags may be removed or escaped in the final pass display.
+
+  Example:
+      "<a href='http://example.com'>Click here</a> for more information"
+
+  Note: Unsupported HTML tags may be stripped or escaped when displayed in the pass.
+  """
+  @type attributed_value() :: String.t() | number() | DateTime.t() | Date.t()
+
+  typedstruct do
+    field :attributed_value, attributed_value(), default: nil
+  end
+
+  @doc """
+  Creates a new FieldContent struct.
+
+  This function initializes a new FieldContent struct with the given attributes.
+  It validates the `attributed_value` using the `ExPass.Utils.Validators.validate_attributed_value/1` function.
+
+  ## Parameters
+
+    * `attrs` - A map of attributes for the FieldContent struct. Defaults to an empty map.
+
+  ## Returns
+
+    * A new `%FieldContent{}` struct.
+
+  ## Raises
+
+    * `ArgumentError` if the `attributed_value` is invalid. The error message will include details about the invalid value and supported types.
+
+  ## Examples
+
+      iex> FieldContent.new(%{attributed_value: "Hello, World!"})
+      %FieldContent{attributed_value: "Hello, World!"}
+
+      iex> FieldContent.new(%{attributed_value: 42})
+      %FieldContent{attributed_value: 42}
+
+      iex> FieldContent.new(%{attributed_value: DateTime.utc_now()})
+      %FieldContent{attributed_value: #DateTime<...>}
+
+      iex> FieldContent.new(%{attributed_value: Date.utc_today()})
+      %FieldContent{attributed_value: ~D[...]}
+
+      iex> FieldContent.new(%{attributed_value: "<a href='http://example.com'>Click here</a>"})
+      %FieldContent{attributed_value: "<a href='http://example.com'>Click here</a>"}
+
+      iex> FieldContent.new()
+      %FieldContent{attributed_value: nil}
+
+  """
+  @spec new(map()) :: %__MODULE__{}
+  def new(attrs \\ %{}) do
+    attrs =
+      attrs
+      |> validate(:attributed_value, &Validators.validate_attributed_value/1)
+
+    struct!(__MODULE__, attrs)
+  end
+
+  defp validate(attrs, key, validator) do
+    case validator.(attrs[key]) do
+      :ok ->
+        attrs
+
+      {:error, reason} ->
+        raise ArgumentError, """
+        Invalid attributed_value: #{inspect(attrs[key])}
+        Reason: #{reason}
+        Supported types are: String (including <a></a> tag), number, DateTime and Date
+        """
+    end
+  end
+end

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -1,0 +1,78 @@
+defmodule ExPass.Utils.Validators do
+  @moduledoc """
+  Provides validation functions for ExPass data types.
+
+  This module contains utility functions to validate different types of data
+  used in pass creation and management, ensuring they meet required formats
+  and constraints.
+
+  These validators are primarily used internally by other ExPass modules.
+  """
+
+  @doc """
+  Validates the type of the attributed value.
+
+  This function checks if the given value is of a valid type for an attributed value.
+  Valid types include numbers, strings, DateTime, and Date.
+
+  ## Parameters
+
+    * `value` - The value to be validated.
+
+  ## Returns
+
+    * `:ok` if the value is of a valid type.
+    * `{:error, "invalid attributed_value type"}` if the value is not of a valid type.
+
+  ## Examples
+
+      iex> validate_attributed_value(42)
+      :ok
+
+      iex> validate_attributed_value("string")
+      :ok
+
+      iex> validate_attributed_value(DateTime.utc_now())
+      :ok
+
+      iex> validate_attributed_value(Date.utc_today())
+      :ok
+
+      iex> validate_attributed_value(%{})
+      {:error, "invalid attributed_value type"}
+
+  """
+  @spec validate_attributed_value(String.t() | number() | DateTime.t() | Date.t() | nil) ::
+          :ok | {:error, String.t()}
+  def validate_attributed_value(nil), do: :ok
+  def validate_attributed_value(value) when is_number(value), do: :ok
+
+  def validate_attributed_value(value) when is_binary(value) do
+    case contains_unsupported_html_tags?(value) do
+      true -> {:error, "contains unsupported HTML tags"}
+      false -> :ok
+    end
+  end
+
+  def validate_attributed_value(%DateTime{} = value) do
+    DateTime.to_iso8601(value)
+
+    :ok
+  end
+
+  def validate_attributed_value(%Date{} = value) do
+    Date.to_iso8601(value)
+
+    :ok
+  end
+
+  def validate_attributed_value(_), do: {:error, "invalid attributed_value type"}
+
+  defp contains_unsupported_html_tags?(string) do
+    # Remove all valid anchor tags
+    string_without_anchors = String.replace(string, ~r{<a\s[^>]*>.*?</a>|<a\s[^>]*/>}, "")
+
+    # Check if any HTML tags remain
+    Regex.match?(~r{<[^>]+>}, string_without_anchors)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -24,7 +24,8 @@ defmodule ExPass.MixProject do
     [
       {:credo, "~> 1.7", only: [:dev, :test], runtime: false},
       {:sobelow, "~> 0.13", only: [:dev, :test], runtime: false},
-      {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false}
+      {:mix_test_watch, "~> 1.0", only: [:dev, :test], runtime: false},
+      {:typed_struct, "~> 0.1.4"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -5,4 +5,5 @@
   "jason": {:hex, :jason, "1.4.4", "b9226785a9aa77b6857ca22832cffa5d5011a667207eb2a0ad56adb5db443b8a", [:mix], [{:decimal, "~> 1.0 or ~> 2.0", [hex: :decimal, repo: "hexpm", optional: true]}], "hexpm", "c5eb0cab91f094599f94d55bc63409236a8ec69a21a67814529e8d5f6cc90b3b"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.2.0", "1f9acd9e1104f62f280e30fc2243ae5e6d8ddc2f7f4dc9bceb454b9a41c82b42", [:mix], [{:file_system, "~> 0.2 or ~> 1.0", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "278dc955c20b3fb9a3168b5c2493c2e5cffad133548d307e0a50c7f2cfbf34f6"},
   "sobelow": {:hex, :sobelow, "0.13.0", "218afe9075904793f5c64b8837cc356e493d88fddde126a463839351870b8d1e", [:mix], [{:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "cd6e9026b85fc35d7529da14f95e85a078d9dd1907a9097b3ba6ac7ebbe34a0d"},
+  "typed_struct": {:hex, :typed_struct, "0.1.4", "25971ce73a8b336dedf2f80e4dafaab111af127ba4773955b66805c89e197f6a", [:mix], [], "hexpm", "c48b743b1812189431e0280941790af150ae5372f7ac51e7097c03a261a35bd6"},
 }

--- a/test/structs/field_content_test.exs
+++ b/test/structs/field_content_test.exs
@@ -1,0 +1,59 @@
+defmodule ExPass.Structs.FieldContentTest do
+  @moduledoc false
+
+  use ExUnit.Case
+
+  alias ExPass.Structs.FieldContent
+
+  describe "field struct" do
+    test "new/1 creates an empty FieldContent struct when no attributes are provided" do
+      assert %FieldContent{attributed_value: nil} = FieldContent.new()
+    end
+
+    test "new/1 creates a valid FieldContent struct with string" do
+      input_string = "Hello, World!"
+      result = FieldContent.new(%{attributed_value: input_string})
+
+      assert result.attributed_value == input_string
+    end
+
+    test "new/1 creates a valid FieldContent struct with number" do
+      input_number = 42
+      result = FieldContent.new(%{attributed_value: input_number})
+
+      assert result.attributed_value == input_number
+    end
+
+    test "new/1 raises ArgumentError for invalid attributed_value types" do
+      invalid_values = [%{}, [1, 2, 3], self(), :stephen]
+
+      for invalid_value <- invalid_values do
+        assert_raise ArgumentError, ~r/Invalid attributed_value:/, fn ->
+          FieldContent.new(%{attributed_value: invalid_value})
+        end
+      end
+    end
+
+    test "new/1 creates a valid FieldContent struct with DateTime" do
+      input_time = DateTime.utc_now()
+      result = FieldContent.new(%{attributed_value: input_time})
+
+      assert result.attributed_value == input_time
+    end
+
+    test "new/1 creates a valid FieldContent struct with Date" do
+      input_date = Date.utc_today()
+      result = FieldContent.new(%{attributed_value: input_date})
+
+      assert result.attributed_value == input_date
+    end
+
+    test "new/1 raises ArgumentError for attributed_value with unsupported HTML tag" do
+      input_value = "<span>Unsupported tag</span>"
+
+      assert_raise ArgumentError, ~r/Invalid attributed_value:/, fn ->
+        FieldContent.new(%{attributed_value: input_value})
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Title

Add FieldContent Struct with Validation and Update TypedStruct Dependency

## Type of Change

- [x] New feature

## Description

This pull request adds the `typed_struct` dependency and introduces the `FieldContent` struct, which represents a field on a pass. The struct supports attributed values, including optional HTML markup for more dynamic content presentation. A `Validators` module is added to ensure that attributed values are properly validated, including checks for unsupported HTML tags. Tests are provided to verify struct creation and validation behaviors.

## Testing

Tests have been added for:
- Creation of `FieldContent` structs with different types of attributed values (string, number, `DateTime`, and `Date`).
- Validation logic that raises `ArgumentError` for unsupported types or invalid HTML markup.

## Impact

- **New Dependency**: The project now relies on `typed_struct` for defining typed structs with defaults.
- **Performance**: Minor performance overhead due to the added validation logic.
- **Security**: Improved security with validation for attributed values, particularly with handling HTML content.

## Additional Information

No known breaking changes, but reviewers should focus on the HTML validation logic in the `Validators` module.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
