### PR TITLE
feat: add change_message attribute to field content

### DIFF
--- a/lib/structs/field_content.ex
+++ b/lib/structs/field_content.ex
@@ -5,21 +5,14 @@ defmodule ExPass.Structs.FieldContent do
   A field displays information on the front or back of a pass, such as a customer's name,
   a balance, or an expiration date.
 
+  For more details, see the [Apple Developer Documentation](https://developer.apple.com/documentation/walletpasses/passfieldcontent).
+
   ## Attributes
 
   - `attributed_value`: The field's value, which can include HTML markup for enhanced
     formatting or interactivity. It can be a string, number, or ISO 8601 date string.
-
-  ## Examples
-
-      iex> field = ExPass.Structs.FieldContent.new(%{attributed_value: "<a href='http://example.com'>Click here</a>"})
-      %ExPass.Structs.FieldContent{attributed_value: "<a href='http://example.com'>Click here</a>"}
-
-      iex> field = ExPass.Structs.FieldContent.new(%{attributed_value: 42})
-      %ExPass.Structs.FieldContent{attributed_value: 42}
-
-      iex> field = ExPass.Structs.FieldContent.new(%{attributed_value: "2023-04-15T14:30:00Z"})
-      %ExPass.Structs.FieldContent{attributed_value: "2023-04-15T14:30:00Z"}
+  - `change_message`: A message that describes the change to the field's value.
+     It should include the '%@' placeholder for the new value.
   """
 
   use TypedStruct
@@ -56,13 +49,15 @@ defmodule ExPass.Structs.FieldContent do
 
   typedstruct do
     field :attributed_value, attributed_value(), default: nil
+    field :change_message, String.t(), default: nil
   end
 
   @doc """
   Creates a new FieldContent struct.
 
   This function initializes a new FieldContent struct with the given attributes.
-  It validates the `attributed_value` using the `ExPass.Utils.Validators.validate_attributed_value/1` function.
+  It validates both the `attributed_value` using the `ExPass.Utils.Validators.validate_attributed_value/1` function
+  and the `change_message` using the `ExPass.Utils.Validators.validate_change_message/1` function.
 
   ## Parameters
 
@@ -75,33 +70,36 @@ defmodule ExPass.Structs.FieldContent do
   ## Raises
 
     * `ArgumentError` if the `attributed_value` is invalid. The error message will include details about the invalid value and supported types.
+    * `ArgumentError` if the `change_message` is invalid. The error message will include details about the invalid value and the required format.
 
   ## Examples
 
       iex> FieldContent.new(%{attributed_value: "Hello, World!"})
-      %FieldContent{attributed_value: "Hello, World!"}
+      %FieldContent{attributed_value: "Hello, World!", change_message: nil}
 
       iex> FieldContent.new(%{attributed_value: 42})
-      %FieldContent{attributed_value: 42}
+      %FieldContent{attributed_value: 42, change_message: nil}
 
-      iex> FieldContent.new(%{attributed_value: DateTime.utc_now()})
-      %FieldContent{attributed_value: #DateTime<...>}
+      iex> datetime = DateTime.utc_now()
+      iex> field_content = FieldContent.new(%{attributed_value: datetime})
+      iex> %FieldContent{attributed_value: ^datetime} = field_content
+      iex> field_content.change_message
+      nil
 
-      iex> FieldContent.new(%{attributed_value: Date.utc_today()})
-      %FieldContent{attributed_value: ~D[...]}
+      iex> date = Date.utc_today()
+      iex> FieldContent.new(%{attributed_value: date})
+      %FieldContent{attributed_value: date, change_message: nil}
 
       iex> FieldContent.new(%{attributed_value: "<a href='http://example.com'>Click here</a>"})
-      %FieldContent{attributed_value: "<a href='http://example.com'>Click here</a>"}
-
-      iex> FieldContent.new()
-      %FieldContent{attributed_value: nil}
-
+      %FieldContent{attributed_value: "<a href='http://example.com'>Click here</a>", change_message: nil}
   """
   @spec new(map()) :: %__MODULE__{}
   def new(attrs \\ %{}) do
     attrs =
       attrs
+      |> Converter.trim_string_values()
       |> validate(:attributed_value, &Validators.validate_attributed_value/1)
+      |> validate(:change_message, &Validators.validate_change_message/1)
 
     struct!(__MODULE__, attrs)
   end
@@ -112,11 +110,27 @@ defmodule ExPass.Structs.FieldContent do
         attrs
 
       {:error, reason} ->
-        raise ArgumentError, """
-        Invalid attributed_value: #{inspect(attrs[key])}
-        Reason: #{reason}
-        Supported types are: String (including <a></a> tag), number, DateTime and Date
-        """
+        cond do
+          key == :attributed_value ->
+            raise ArgumentError, """
+            Invalid attributed_value: #{inspect(attrs[key])}
+            Reason: #{reason}
+            Supported types are: String (including <a></a> tag), number, DateTime and Date
+            """
+
+          key == :change_message ->
+            raise ArgumentError, """
+            Invalid change_message: #{inspect(attrs[key])}
+            Reason: #{reason}
+            The change_message must be a string containing the '%@' placeholder for the new value.
+            """
+
+          true ->
+            raise ArgumentError, """
+            Invalid value for #{key}: #{inspect(attrs[key])}
+            Reason: #{reason}
+            """
+        end
     end
   end
 
@@ -124,9 +138,10 @@ defmodule ExPass.Structs.FieldContent do
     def encode(field_content, opts) do
       field_content
       |> Map.from_struct()
-      |> Enum.filter(fn {_, v} -> v != nil end)
-      |> Enum.map(fn {k, v} -> {Converter.camelize_key(k), v} end)
-      |> Enum.into(%{})
+      |> Enum.reduce(%{}, fn
+        {_k, nil}, acc -> acc
+        {k, v}, acc -> Map.put(acc, Converter.camelize_key(k), v)
+      end)
       |> Jason.Encode.map(opts)
     end
   end

--- a/lib/utils/converter.ex
+++ b/lib/utils/converter.ex
@@ -5,6 +5,36 @@ defmodule ExPass.Utils.Converter do
   """
 
   @doc """
+  Trims whitespace from string values in a map while preserving non-string values.
+
+  This function iterates through the key-value pairs of the input map. For each pair,
+  if the value is a string, it trims leading and trailing whitespace. Non-string
+  values are left unchanged.
+
+  ## Parameters
+
+    * `attrs` - A map containing key-value pairs to be processed.
+
+  ## Returns
+
+    * A new map with the same keys as the input, but with string values trimmed.
+
+  ## Examples
+
+      iex> attrs = %{name: "  John Doe  ", age: 30, email: " john@example.com "}
+      iex> ExPass.Utils.Converter.trim_string_values(attrs)
+      %{name: "John Doe", age: 30, email: "john@example.com"}
+
+  """
+  @spec trim_string_values(map()) :: map()
+  def trim_string_values(attrs) do
+    Map.new(attrs, fn {key, value} ->
+      trimmed_value = if is_binary(value), do: String.trim(value), else: value
+      {key, trimmed_value}
+    end)
+  end
+
+  @doc """
   Converts a key (atom or string) to camelCase format.
 
   ## Examples

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -68,6 +68,44 @@ defmodule ExPass.Utils.Validators do
 
   def validate_attributed_value(_), do: {:error, "invalid attributed_value type"}
 
+  @doc """
+  Validates the change_message field.
+
+  The change_message must be a string containing the '%@' placeholder for the new value.
+
+  ## Returns
+
+    * `:ok` if the value is a valid change_message string.
+    * `{:error, reason}` if the value is not valid, where reason is a string explaining the error.
+
+  ## Examples
+
+      iex> validate_change_message("Gate changed to %@")
+      :ok
+
+      iex> validate_change_message("Invalid message without placeholder")
+      {:error, "change_message must contain '%@' placeholder"}
+
+      iex> validate_change_message(nil)
+      :ok
+
+      iex> validate_change_message(42)
+      {:error, "change_message must be a string"}
+
+  """
+  @spec validate_change_message(String.t() | nil) :: :ok | {:error, String.t()}
+  def validate_change_message(nil), do: :ok
+
+  def validate_change_message(value) when is_binary(value) do
+    if String.contains?(value, "%@") do
+      :ok
+    else
+      {:error, "change_message must contain '%@' placeholder"}
+    end
+  end
+
+  def validate_change_message(_), do: {:error, "change_message must be a string"}
+
   defp contains_unsupported_html_tags?(string) do
     # Remove all valid anchor tags
     string_without_anchors = String.replace(string, ~r{<a\s[^>]*>.*?</a>|<a\s[^>]*/>}, "")


### PR DESCRIPTION
## Title

Upgrade typedstruct dependency and add JSON encoding for FieldContent struct

## Type of Change

- [x] New feature
- [x] Refactoring

## Description

This pull request includes the following updates:
- Migrated from the unmaintained `typed_struct` to the maintained `typedstruct` package to ensure future support and compatibility.
- Added JSON encoding functionality to the `FieldContent` struct in the `ExPass.Structs.FieldContent` module. The new encoder converts `FieldContent` struct data into camelCase keys and filters out `nil` values. This is critical for ensuring consistent interaction with external systems via APIs.
- Introduced a new attribute `change_message` in the `FieldContent` struct, which allows descriptive messages when field values change.

## Testing

- Updated test cases for `FieldContent` to include validation of the `change_message` field.
- Added tests for the new JSON encoding functionality, including key formatting (camelCase) and exclusion of `nil` values.

## Impact

- Dependencies: Migrating to `typedstruct` may introduce minor changes in struct behavior, but no breaking changes are expected.
- External APIs that consume `FieldContent` JSON data should now receive properly formatted camelCase keys, ensuring compatibility with standardized systems.
- Developers must now ensure that `change_message` follows the format requirements (`%@` placeholder).

## Additional Information

N/A

