### PR TITLE
feat: Add currency_code field to FieldContent struct

### DIFF
--- a/lib/structs/field_content.ex
+++ b/lib/structs/field_content.ex
@@ -13,6 +13,8 @@ defmodule ExPass.Structs.FieldContent do
     formatting or interactivity. It can be a string, number, or ISO 8601 date string.
   - `change_message`: A message that describes the change to the field's value.
      It should include the '%@' placeholder for the new value.
+  - `currency_code`: The ISO 4217 currency code for the field's value, if applicable.
+     This is used when the field represents a monetary amount.
   """
 
   use TypedStruct
@@ -50,6 +52,7 @@ defmodule ExPass.Structs.FieldContent do
   typedstruct do
     field :attributed_value, attributed_value(), default: nil
     field :change_message, String.t(), default: nil
+    field :currency_code, String.t(), default: nil
   end
 
   @doc """
@@ -100,6 +103,7 @@ defmodule ExPass.Structs.FieldContent do
       |> Converter.trim_string_values()
       |> validate(:attributed_value, &Validators.validate_attributed_value/1)
       |> validate(:change_message, &Validators.validate_change_message/1)
+      |> validate(:currency_code, &Validators.validate_currency_code/1)
 
     struct!(__MODULE__, attrs)
   end

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -9,6 +9,8 @@ defmodule ExPass.Utils.Validators do
   These validators are primarily used internally by other ExPass modules.
   """
 
+  @currency_code_regex ~r/^(AED|AFN|ALL|AMD|ANG|AOA|ARS|AUD|AWG|AZN|BAM|BBD|BDT|BGN|BHD|BIF|BMD|BND|BOB|BOV|BRL|BSD|BTN|BWP|BYN|BZD|CAD|CDF|CHE|CHF|CHW|CLF|CLP|CNY|COP|COU|CRC|CUP|CVE|CZK|DJF|DKK|DOP|DZD|EGP|ERN|ETB|EUR|FJD|FKP|GBP|GEL|GHS|GIP|GMD|GNF|GTQ|GYD|HKD|HNL|HTG|HUF|IDR|ILS|INR|IQD|IRR|ISK|JMD|JOD|JPY|KES|KGS|KHR|KMF|KPW|KRW|KWD|KYD|KZT|LAK|LBP|LKR|LRD|LSL|LYD|MAD|MDL|MGA|MKD|MMK|MNT|MOP|MRU|MUR|MVR|MWK|MXN|MXV|MYR|MZN|NAD|NGN|NIO|NOK|NPR|NZD|OMR|PAB|PEN|PGK|PHP|PKR|PLN|PYG|QAR|RON|RSD|RUB|RWF|SAR|SBD|SCR|SDG|SEK|SGD|SHP|SLE|SOS|SRD|SSP|STN|SVC|SYP|SZL|THB|TJS|TMT|TND|TOP|TRY|TTD|TWD|TZS|UAH|UGX|USD|USN|UYI|UYU|UYW|UZS|VED|VES|VND|VUV|WST|XAF|XAG|XAU|XBA|XBB|XBC|XBD|XCD|XDR|XOF|XPD|XPF|XPT|XSU|XTS|XUA|XXX|YER|ZAR|ZMW|ZWG|ZWL)$/
+
   @doc """
   Validates the type of the attributed value.
 
@@ -105,6 +107,49 @@ defmodule ExPass.Utils.Validators do
   end
 
   def validate_change_message(_), do: {:error, "change_message must be a string"}
+
+  @doc """
+  Validates the currency_code field.
+
+  The currency_code must be a valid ISO 4217 currency code string or atom.
+
+  ## Returns
+
+    * `:ok` if the value is a valid ISO 4217 currency code string or atom.
+    * `{:error, reason}` if the value is not valid, where reason is a string explaining the error.
+
+  ## Examples
+
+      iex> validate_currency_code("USD")
+      :ok
+
+      iex> validate_currency_code(:EUR)
+      :ok
+
+      iex> validate_currency_code("INVALID")
+      {:error, "Invalid currency code"}
+
+      iex> validate_currency_code(nil)
+      :ok
+
+      iex> validate_currency_code(123)
+      {:error, "Currency code must be a string or atom"}
+
+  """
+  @spec validate_currency_code(String.t() | atom() | nil) :: :ok | {:error, String.t()}
+  def validate_currency_code(nil), do: :ok
+
+  def validate_currency_code(value) when is_binary(value) or is_atom(value) do
+    value_string = if is_atom(value), do: Atom.to_string(value), else: value
+
+    if Regex.match?(@currency_code_regex, value_string) do
+      :ok
+    else
+      {:error, "Invalid currency code #{value_string}"}
+    end
+  end
+
+  def validate_currency_code(_), do: {:error, "Currency code must be a string or atom"}
 
   defp contains_unsupported_html_tags?(string) do
     # Remove all valid anchor tags

--- a/test/structs/field_content_test.exs
+++ b/test/structs/field_content_test.exs
@@ -98,4 +98,52 @@ defmodule ExPass.Structs.FieldContentTest do
                ~s({"attributedValue":"<a href='http://example.com'>Link</a>"})
     end
   end
+
+  describe "currency_code" do
+    test "new/1 creates a valid FieldContent struct with valid currency_code as string" do
+      input = %{attributed_value: 100, currency_code: "USD"}
+      result = FieldContent.new(input)
+
+      assert %FieldContent{attributed_value: 100, currency_code: "USD"} = result
+      assert Jason.encode!(result) == ~s({"attributedValue":100,"currencyCode":"USD"})
+    end
+
+    test "new/1 creates a valid FieldContent struct with valid currency_code as atom" do
+      input = %{attributed_value: 100, currency_code: :USD}
+      result = FieldContent.new(input)
+
+      assert %FieldContent{attributed_value: 100, currency_code: :USD} = result
+      assert Jason.encode!(result) == ~s({"attributedValue":100,"currencyCode":"USD"})
+    end
+
+    test "new/1 raises ArgumentError for invalid currency_code" do
+      assert_raise ArgumentError, ~r/Invalid currency code INVALID/, fn ->
+        FieldContent.new(%{attributed_value: 100, currency_code: "INVALID"})
+      end
+
+      assert_raise ArgumentError, ~r/Invalid currency code INVALID/, fn ->
+        FieldContent.new(%{attributed_value: 100, currency_code: :INVALID})
+      end
+    end
+
+    test "new/1 allows nil currency_code" do
+      result = FieldContent.new(%{attributed_value: 100})
+
+      assert %FieldContent{attributed_value: 100, currency_code: nil} = result
+      assert Jason.encode!(result) == ~s({"attributedValue":100})
+    end
+
+    test "new/1 raises ArgumentError when currency_code is not a string or atom" do
+      assert_raise ArgumentError, ~r/Currency code must be a string or atom/, fn ->
+        FieldContent.new(%{attributed_value: 100, currency_code: 123})
+      end
+    end
+
+    test "new/1 trims whitespace from currency_code string" do
+      result = FieldContent.new(%{currency_code: "  USD  "})
+
+      assert %FieldContent{attributed_value: nil, currency_code: "USD"} = result
+      assert Jason.encode!(result) == ~s({"currencyCode":"USD"})
+    end
+  end
 end


### PR DESCRIPTION
## Title
Add `currency_code` field and validation to `FieldContent` struct

## Type of Change
- [x] New feature

## Description
This PR introduces a `currency_code` field to the `FieldContent` struct, allowing the system to handle fields that represent monetary values more accurately. The field adheres to the ISO 4217 standard, ensuring correct and consistent use of currency codes.

Additionally, validation logic has been implemented to ensure only valid ISO 4217 codes are accepted. Unit tests have been added to cover the new field and its associated validation.

## Testing
- Verified the correct handling of valid and invalid currency codes in the `FieldContent` struct.
- Added unit tests to check proper serialization and validation.
- Tested edge cases where the `currency_code` field is missing or contains invalid values.

## Impact
- Affects all systems interacting with the `FieldContent` struct that deal with monetary data.
- Minor performance impact due to added validation logic.
- Backward-compatible as the `currency_code` field is optional and defaults to `nil`.

## Additional Information
This change introduces stricter validation for currency-related fields but does not affect existing non-monetary data.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
