### PR TITLE
feat: Add validation for text alignment field in FieldContent struct

### DIFF
--- a/lib/structs/field_content.ex
+++ b/lib/structs/field_content.ex
@@ -56,6 +56,13 @@ defmodule ExPass.Structs.FieldContent do
      * "PKNumberStyleScientific"
      * "PKNumberStyleSpellOut"
 
+  - `text_alignment`: The alignment of the text in the field.
+     Supported values are:
+     * "PKTextAlignmentLeft"
+     * "PKTextAlignmentCenter"
+     * "PKTextAlignmentRight"
+     * "PKTextAlignmentNatural"
+
   - `value`: The value to use for the field. This can be a localizable string, ISO 8601 date, or number.
      This field is required. A date or time value must include a time zone.
   """
@@ -130,6 +137,17 @@ defmodule ExPass.Structs.FieldContent do
   @type number_style() :: String.t()
 
   @typedoc """
+  The alignment of the text in the field.
+
+  Optional. Valid values are:
+  - "PKTextAlignmentLeft"
+  - "PKTextAlignmentCenter"
+  - "PKTextAlignmentRight"
+  - "PKTextAlignmentNatural"
+  """
+  @type text_alignment() :: String.t()
+
+  @typedoc """
   The value to use for the field.
 
   Required. Can be:
@@ -152,6 +170,7 @@ defmodule ExPass.Structs.FieldContent do
     field :key, String.t(), enforce: true
     field :label, String.t(), default: nil
     field :number_style, number_style(), default: nil
+    field :text_alignment, text_alignment(), default: nil
     field :value, value(), enforce: true
   end
 
@@ -170,6 +189,7 @@ defmodule ExPass.Structs.FieldContent do
   • key
   • label
   • number_style
+  • text_alignment
   • value
 
   ## Parameters
@@ -187,22 +207,22 @@ defmodule ExPass.Structs.FieldContent do
   ## Examples
 
       iex> FieldContent.new(%{key: "field1", value: "Hello, World!"})
-      %FieldContent{key: "field1", attributed_value: nil, change_message: nil, currency_code: nil, data_detector_types: nil, date_style: nil, ignores_time_zone: nil, is_relative: nil, label: nil, number_style: nil, value: "Hello, World!"}
+      %FieldContent{key: "field1", attributed_value: nil, change_message: nil, currency_code: nil, data_detector_types: nil, date_style: nil, ignores_time_zone: nil, is_relative: nil, label: nil, number_style: nil, text_alignment: nil, value: "Hello, World!"}
 
-      iex> FieldContent.new(%{key: "field2", value: 42, data_detector_types: ["PKDataDetectorTypePhoneNumber"], date_style: "PKDateStyleShort", ignores_time_zone: true, is_relative: false, number_style: "PKNumberStyleDecimal"})
-      %FieldContent{key: "field2", attributed_value: nil, change_message: nil, currency_code: nil, data_detector_types: ["PKDataDetectorTypePhoneNumber"], date_style: "PKDateStyleShort", ignores_time_zone: true, is_relative: false, label: nil, number_style: "PKNumberStyleDecimal", value: 42}
+      iex> FieldContent.new(%{key: "field2", value: 42, data_detector_types: ["PKDataDetectorTypePhoneNumber"], date_style: "PKDateStyleShort", ignores_time_zone: true, is_relative: false, number_style: "PKNumberStyleDecimal", text_alignment: "PKTextAlignmentCenter"})
+      %FieldContent{key: "field2", attributed_value: nil, change_message: nil, currency_code: nil, data_detector_types: ["PKDataDetectorTypePhoneNumber"], date_style: "PKDateStyleShort", ignores_time_zone: true, is_relative: false, label: nil, number_style: "PKNumberStyleDecimal", text_alignment: "PKTextAlignmentCenter", value: 42}
 
       iex> datetime = ~U[2023-04-15 14:30:00Z]
-      iex> field_content = FieldContent.new(%{key: "field3", value: datetime, currency_code: "USD", date_style: "PKDateStyleLong", ignores_time_zone: true, is_relative: true})
-      iex> %FieldContent{key: "field3", value: ^datetime, currency_code: "USD", date_style: "PKDateStyleLong", ignores_time_zone: true, is_relative: true} = field_content
+      iex> field_content = FieldContent.new(%{key: "field3", value: datetime, currency_code: "USD", date_style: "PKDateStyleLong", ignores_time_zone: true, is_relative: true, text_alignment: "PKTextAlignmentRight"})
+      iex> %FieldContent{key: "field3", value: ^datetime, currency_code: "USD", date_style: "PKDateStyleLong", ignores_time_zone: true, is_relative: true, text_alignment: "PKTextAlignmentRight"} = field_content
       iex> field_content.change_message
       nil
 
-      iex> FieldContent.new(%{key: "field4", value: "<a href='http://example.com'>Click here</a>", data_detector_types: ["PKDataDetectorTypeLink"], date_style: "PKDateStyleFull", is_relative: false, number_style: "PKNumberStylePercent"})
-      %FieldContent{key: "field4", attributed_value: nil, change_message: nil, currency_code: nil, data_detector_types: ["PKDataDetectorTypeLink"], date_style: "PKDateStyleFull", ignores_time_zone: nil, is_relative: false, label: nil, number_style: "PKNumberStylePercent", value: "<a href='http://example.com'>Click here</a>"}
+      iex> FieldContent.new(%{key: "field4", value: "<a href='http://example.com'>Click here</a>", data_detector_types: ["PKDataDetectorTypeLink"], date_style: "PKDateStyleFull", is_relative: false, number_style: "PKNumberStylePercent", text_alignment: "PKTextAlignmentLeft"})
+      %FieldContent{key: "field4", attributed_value: nil, change_message: nil, currency_code: nil, data_detector_types: ["PKDataDetectorTypeLink"], date_style: "PKDateStyleFull", ignores_time_zone: nil, is_relative: false, label: nil, number_style: "PKNumberStylePercent", text_alignment: "PKTextAlignmentLeft", value: "<a href='http://example.com'>Click here</a>"}
 
-      iex> FieldContent.new(%{key: "field5", value: "No detectors", data_detector_types: [], change_message: "Updated to %@", ignores_time_zone: true, is_relative: true, label: "Field Label", number_style: "PKNumberStyleScientific"})
-      %FieldContent{key: "field5", attributed_value: nil, change_message: "Updated to %@", currency_code: nil, data_detector_types: [], date_style: nil, ignores_time_zone: true, is_relative: true, label: "Field Label", number_style: "PKNumberStyleScientific", value: "No detectors"}
+      iex> FieldContent.new(%{key: "field5", value: "No detectors", data_detector_types: [], change_message: "Updated to %@", ignores_time_zone: true, is_relative: true, label: "Field Label", number_style: "PKNumberStyleScientific", text_alignment: "PKTextAlignmentNatural"})
+      %FieldContent{key: "field5", attributed_value: nil, change_message: "Updated to %@", currency_code: nil, data_detector_types: [], date_style: nil, ignores_time_zone: true, is_relative: true, label: "Field Label", number_style: "PKNumberStyleScientific", text_alignment: "PKTextAlignmentNatural", value: "No detectors"}
   """
   @spec new(map()) :: %__MODULE__{}
   def new(attrs \\ %{}) do
@@ -219,6 +239,7 @@ defmodule ExPass.Structs.FieldContent do
       |> validate(:key, &Validators.validate_required_string(&1, :key))
       |> validate(:label, &Validators.validate_optional_string(&1, :label))
       |> validate(:number_style, &Validators.validate_number_style/1)
+      |> validate(:text_alignment, &Validators.validate_text_alignment/1)
       |> validate(:value, &Validators.validate_required_value(&1, :value))
 
     struct!(__MODULE__, attrs)

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -33,6 +33,13 @@ defmodule ExPass.Utils.Validators do
     "PKNumberStyleSpellOut"
   ]
 
+  @valid_text_alignments [
+    "PKTextAlignmentLeft",
+    "PKTextAlignmentCenter",
+    "PKTextAlignmentRight",
+    "PKTextAlignmentNatural"
+  ]
+
   @doc """
   Validates the type of the attributed value.
 
@@ -487,6 +494,51 @@ defmodule ExPass.Utils.Validators do
 
   def validate_required_value(_value, field_name),
     do: {:error, "#{field_name} must be a string, number, DateTime, or Date"}
+
+  @doc """
+  Validates the text alignment value.
+
+  This function checks if the given value is a valid text alignment option.
+  Valid options are "PKTextAlignmentLeft", "PKTextAlignmentCenter", "PKTextAlignmentRight", and "PKTextAlignmentNatural".
+
+  ## Parameters
+
+    * `value` - The text alignment value to validate.
+
+  ## Returns
+
+    * `:ok` if the value is valid.
+    * `{:error, message}` if the value is invalid, where `message` is a string explaining the error.
+
+  ## Examples
+
+      iex> validate_text_alignment("PKTextAlignmentLeft")
+      :ok
+
+      iex> validate_text_alignment("PKTextAlignmentCenter")
+      :ok
+
+      iex> validate_text_alignment("PKTextAlignmentRight")
+      :ok
+
+      iex> validate_text_alignment("PKTextAlignmentNatural")
+      :ok
+
+      iex> validate_text_alignment("InvalidAlignment")
+      {:error, "Invalid text_alignment. Supported values are PKTextAlignmentLeft, PKTextAlignmentCenter, PKTextAlignmentRight, PKTextAlignmentNatural"}
+
+      iex> validate_text_alignment(nil)
+      :ok
+
+  """
+  @spec validate_text_alignment(String.t() | nil) :: :ok | {:error, String.t()}
+  def validate_text_alignment(nil), do: :ok
+  def validate_text_alignment(value) when value in @valid_text_alignments, do: :ok
+
+  def validate_text_alignment(_),
+    do:
+      {:error,
+       "Invalid text_alignment. Supported values are #{Enum.join(@valid_text_alignments, ", ")}"}
 
   defp contains_unsupported_html_tags?(string) do
     # Remove all valid anchor tags

--- a/mix.exs
+++ b/mix.exs
@@ -8,7 +8,8 @@ defmodule ExPass.MixProject do
       elixir: "~> 1.16",
       config_path: "./config/config.exs",
       start_permanent: Mix.env() == :prod,
-      deps: deps()
+      deps: deps(),
+      test_coverage: [threshold: 97.56]
     ]
   end
 

--- a/test/structs/field_content_test.exs
+++ b/test/structs/field_content_test.exs
@@ -7,8 +7,8 @@ defmodule ExPass.Structs.FieldContentTest do
   doctest FieldContent
 
   describe "new/1" do
-    test "creates a new FieldContent with default empty map" do
-      assert_raise ArgumentError, ~r/The :key field is required/, fn ->
+    test "new/1 raises ArgumentError when called with no arguments" do
+      assert_raise ArgumentError, "key is a required field and must be a non-empty string", fn ->
         FieldContent.new()
       end
     end
@@ -19,9 +19,15 @@ defmodule ExPass.Structs.FieldContentTest do
     end
 
     test "raises ArgumentError for invalid attributes" do
-      assert_raise ArgumentError, ~r/Invalid data_detector_types/, fn ->
-        FieldContent.new(%{key: "test", value: "test", data_detector_types: ["InvalidType"]})
-      end
+      assert_raise ArgumentError,
+                   "Invalid data detector type: InvalidType. Supported types are: PKDataDetectorTypePhoneNumber, PKDataDetectorTypeLink, PKDataDetectorTypeAddress, PKDataDetectorTypeCalendarEvent",
+                   fn ->
+                     FieldContent.new(%{
+                       key: "test",
+                       value: "test",
+                       data_detector_types: ["InvalidType"]
+                     })
+                   end
     end
   end
 


### PR DESCRIPTION
## Title
Add optional `text_alignment` field to `FieldContent` struct with validation

## Type of Change
- [x] New feature

## Description
This PR adds a new optional `text_alignment` field to the `FieldContent` struct, allowing the text in a field to be aligned to the left, center, right, or natural alignment. The supported values are "PKTextAlignmentLeft", "PKTextAlignmentCenter", "PKTextAlignmentRight", and "PKTextAlignmentNatural". Validation has been implemented to ensure that only these values are accepted. Tests have been updated to verify correct functionality.

## Testing
New tests have been added to ensure that the `text_alignment` field accepts valid values and rejects invalid ones. Behavior when the field is omitted or set to `nil` has also been tested to ensure correct default handling.

## Impact
This change is backward-compatible since the `text_alignment` field is optional. It enhances the flexibility of text presentation within the `FieldContent` struct.

## Additional Information
N/A

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

