### PR TITLE
feat: Add barcode format validation to Barcodes struct

### DIFF
--- a/lib/structs/barcodes.ex
+++ b/lib/structs/barcodes.ex
@@ -10,6 +10,8 @@ defmodule ExPass.Structs.Barcodes do
   ## Attributes
 
   - `alt_text`: Optional. Text displayed near the barcode. For example, a human-readable version of the barcode data.
+  - `format`: Required. The format of the barcode. Possible values are: PKBarcodeFormatQR, PKBarcodeFormatPDF417, PKBarcodeFormatAztec, PKBarcodeFormatCode128.
+    Note: The barcode format PKBarcodeFormatCode128 isn't supported for watchOS.
   """
 
   use TypedStruct
@@ -19,6 +21,7 @@ defmodule ExPass.Structs.Barcodes do
 
   typedstruct do
     field :alt_text, String.t()
+    field :format, String.t(), enforce: true
   end
 
   @doc """
@@ -34,8 +37,8 @@ defmodule ExPass.Structs.Barcodes do
 
   ## Examples
 
-      iex> Barcodes.new(%{alt_text: "Scan this QR code"})
-      %Barcodes{alt_text: "Scan this QR code"}
+      iex> Barcodes.new(%{alt_text: "Scan this QR code", format: "PKBarcodeFormatQR"})
+      %Barcodes{alt_text: "Scan this QR code", format: "PKBarcodeFormatQR"}
 
   """
   @spec new(map()) :: %__MODULE__{}
@@ -44,6 +47,7 @@ defmodule ExPass.Structs.Barcodes do
       attrs
       |> Converter.trim_string_values()
       |> validate(:alt_text, &Validators.validate_optional_string(&1, :alt_text))
+      |> validate(:format, &Validators.validate_barcode_format/1)
 
     struct!(__MODULE__, attrs)
   end

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -221,6 +221,13 @@ defmodule ExPass.Utils.Validators do
     "PKTextAlignmentNatural"
   ]
 
+  @valid_barcode_formats [
+    "PKBarcodeFormatQR",
+    "PKBarcodeFormatPDF417",
+    "PKBarcodeFormatAztec",
+    "PKBarcodeFormatCode128"
+  ]
+
   @doc """
   Validates the type of the attributed value.
 
@@ -677,6 +684,45 @@ defmodule ExPass.Utils.Validators do
 
   def validate_text_alignment(_),
     do: {:error, "text_alignment must be a string"}
+
+  @doc """
+  Validates the barcode format.
+
+  This function checks if the given value is a valid barcode format.
+  Valid formats are "PKBarcodeFormatQR", "PKBarcodeFormatPDF417", "PKBarcodeFormatAztec", and "PKBarcodeFormatCode128".
+
+  ## Parameters
+
+    * `value` - The barcode format value to validate.
+
+  ## Returns
+
+    * `:ok` if the value is valid.
+    * `{:error, message}` if the value is invalid, where `message` is a string explaining the error.
+
+  ## Examples
+
+      iex> validate_barcode_format("PKBarcodeFormatQR")
+      :ok
+
+      iex> validate_barcode_format("PKBarcodeFormatPDF417")
+      :ok
+
+      iex> validate_barcode_format("InvalidFormat")
+      {:error, "Invalid format: InvalidFormat. Supported formats are: PKBarcodeFormatQR, PKBarcodeFormatPDF417, PKBarcodeFormatAztec, PKBarcodeFormatCode128"}
+
+      iex> validate_barcode_format(nil)
+      {:error, "format is required"}
+
+  """
+  @spec validate_barcode_format(String.t() | nil) :: :ok | {:error, String.t()}
+  def validate_barcode_format(nil), do: {:error, "format is required"}
+
+  def validate_barcode_format(value) when is_binary(value) do
+    validate_inclusion(value, @valid_barcode_formats, "format")
+  end
+
+  def validate_barcode_format(_), do: {:error, "format must be a string"}
 
   defp validate_inclusion(value, valid_values, field_name) do
     if value in valid_values do

--- a/test/structs/barcodes_test.exs
+++ b/test/structs/barcodes_test.exs
@@ -7,48 +7,85 @@ defmodule ExPass.Structs.BarcodesTest do
   doctest Barcodes
 
   describe "new/0" do
-    test "creates an empty Barcodes struct" do
-      barcode = Barcodes.new()
-      assert %Barcodes{alt_text: nil} = barcode
-    end
-
-    test "encodes an empty Barcodes struct as an empty JSON object" do
-      barcode = Barcodes.new()
-      encoded = Jason.encode!(barcode)
-      assert encoded == "{}"
+    test "raises ArgumentError when format is not provided" do
+      assert_raise ArgumentError, "format is required", fn ->
+        Barcodes.new()
+      end
     end
   end
 
   describe "alt_text" do
-    test "creates a valid Barcodes struct with alt_text" do
+    test "creates a valid Barcodes struct with alt_text and format" do
       barcode =
         Barcodes.new(%{
-          alt_text: "Scan this QR code"
+          alt_text: "Scan this QR code",
+          format: "PKBarcodeFormatQR"
         })
 
       assert %Barcodes{
-               alt_text: "Scan this QR code"
+               alt_text: "Scan this QR code",
+               format: "PKBarcodeFormatQR"
              } = barcode
 
       encoded = Jason.encode!(barcode)
       assert encoded =~ ~s("altText":"Scan this QR code")
+      assert encoded =~ ~s("format":"PKBarcodeFormatQR")
     end
 
     test "creates a valid Barcodes struct without alt_text" do
-      barcode = Barcodes.new(%{})
+      barcode = Barcodes.new(%{format: "PKBarcodeFormatQR"})
 
-      assert %Barcodes{alt_text: nil} = barcode
+      assert %Barcodes{alt_text: nil, format: "PKBarcodeFormatQR"} = barcode
 
       encoded = Jason.encode!(barcode)
-      assert encoded == "{}"
+      assert encoded == ~s({"format":"PKBarcodeFormatQR"})
     end
 
     test "raises ArgumentError when alt_text is not a string" do
       assert_raise ArgumentError, "alt_text must be a string if provided", fn ->
         Barcodes.new(%{
-          alt_text: 123
+          alt_text: 123,
+          format: "PKBarcodeFormatQR"
         })
       end
+    end
+  end
+
+  describe "format field" do
+    test "creates a valid Barcodes struct with format" do
+      valid_formats = [
+        "PKBarcodeFormatQR",
+        "PKBarcodeFormatPDF417",
+        "PKBarcodeFormatAztec",
+        "PKBarcodeFormatCode128"
+      ]
+
+      for format <- valid_formats do
+        barcode = Barcodes.new(%{format: format})
+        assert %Barcodes{format: ^format} = barcode
+        encoded = Jason.encode!(barcode)
+        assert encoded =~ ~s("format":"#{format}")
+      end
+    end
+
+    test "raises ArgumentError when format is missing" do
+      assert_raise ArgumentError, "format is required", fn ->
+        Barcodes.new(%{})
+      end
+    end
+
+    test "raises ArgumentError when format is not a string" do
+      assert_raise ArgumentError, "format must be a string", fn ->
+        Barcodes.new(%{format: 123})
+      end
+    end
+
+    test "raises ArgumentError when format is an invalid value" do
+      assert_raise ArgumentError,
+                   "Invalid format: InvalidFormat. Supported values are: PKBarcodeFormatQR, PKBarcodeFormatPDF417, PKBarcodeFormatAztec, PKBarcodeFormatCode128",
+                   fn ->
+                     Barcodes.new(%{format: "InvalidFormat"})
+                   end
     end
   end
 end


### PR DESCRIPTION
## Title
Add Barcode Format Validation to Barcodes Struct

## Type of Change
- [x] New feature

## Description
This pull request introduces a feature that adds barcode format validation to the `Barcodes` struct in the `ExPass` repository. The update includes:

1. **Barcode Format Field**: A new `:format` field has been added to the `Barcodes` struct, which is now mandatory. This field allows for the specification of barcode formats, including `PKBarcodeFormatQR`, `PKBarcodeFormatPDF417`, `PKBarcodeFormatAztec`, and `PKBarcodeFormatCode128`. It is worth noting that `PKBarcodeFormatCode128` is not supported for watchOS.
   
2. **Validation**: A new validator, `validate_barcode_format/1`, has been implemented to ensure that only valid barcode formats are accepted. This function checks if the provided barcode format matches one of the supported formats.

3. **Tests**: Tests have been added and updated to verify the correct behavior of the new barcode format functionality. These tests check for valid formats, missing formats, and invalid formats, ensuring robustness.

## Testing
- **Unit Tests**: Several test cases have been added to ensure proper functionality:
  - Tests to confirm that a `Barcodes` struct cannot be created without a valid barcode format.
  - Tests to validate correct encoding of barcodes with and without `alt_text`.
  - Tests to ensure invalid formats are properly rejected and raise appropriate errors.

## Impact
- **Codebase Impact**: 
  - The `Barcodes` struct now requires a valid `:format` field for instantiation.
  - The validation logic ensures that only supported formats are allowed, which could lead to runtime errors if incorrect formats are passed.
  
- **System Behavior**: The introduction of the mandatory `format` field will enforce stronger data integrity, reducing the likelihood of invalid barcode formats being processed downstream.

## Additional Information
- **Backward Compatibility**: This change introduces a breaking change since the `format` field is now required when creating a `Barcodes` struct. Any existing code that does not provide a `format` will need to be updated to avoid runtime errors.
  
- **Error Messaging**: The error messages are descriptive, providing feedback on why a barcode format is invalid and listing the supported formats.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
