### PR TITLE
feat: Add message field to Barcodes struct

### DIFF
--- a/lib/structs/barcodes.ex
+++ b/lib/structs/barcodes.ex
@@ -12,6 +12,7 @@ defmodule ExPass.Structs.Barcodes do
   - `alt_text`: Optional. Text displayed near the barcode. For example, a human-readable version of the barcode data.
   - `format`: Required. The format of the barcode. Possible values are: PKBarcodeFormatQR, PKBarcodeFormatPDF417, PKBarcodeFormatAztec, PKBarcodeFormatCode128.
     Note: The barcode format PKBarcodeFormatCode128 isn't supported for watchOS.
+  - `message`: Required. The message or payload to display as a barcode.
   """
 
   use TypedStruct
@@ -22,6 +23,7 @@ defmodule ExPass.Structs.Barcodes do
   typedstruct do
     field :alt_text, String.t()
     field :format, String.t(), enforce: true
+    field :message, String.t(), enforce: true
   end
 
   @doc """
@@ -37,8 +39,8 @@ defmodule ExPass.Structs.Barcodes do
 
   ## Examples
 
-      iex> Barcodes.new(%{alt_text: "Scan this QR code", format: "PKBarcodeFormatQR"})
-      %Barcodes{alt_text: "Scan this QR code", format: "PKBarcodeFormatQR"}
+      iex> Barcodes.new(%{alt_text: "Scan this QR code", format: "PKBarcodeFormatQR", message: "123456789"})
+      %Barcodes{alt_text: "Scan this QR code", format: "PKBarcodeFormatQR", message: "123456789"}
 
   """
   @spec new(map()) :: %__MODULE__{}
@@ -48,6 +50,7 @@ defmodule ExPass.Structs.Barcodes do
       |> Converter.trim_string_values()
       |> validate(:alt_text, &Validators.validate_optional_string(&1, :alt_text))
       |> validate(:format, &Validators.validate_barcode_format/1)
+      |> validate(:message, &Validators.validate_required_string(&1, :message))
 
     struct!(__MODULE__, attrs)
   end

--- a/test/structs/barcodes_test.exs
+++ b/test/structs/barcodes_test.exs
@@ -19,33 +19,40 @@ defmodule ExPass.Structs.BarcodesTest do
       barcode =
         Barcodes.new(%{
           alt_text: "Scan this QR code",
-          format: "PKBarcodeFormatQR"
+          format: "PKBarcodeFormatQR",
+          message: "Test message"
         })
 
       assert %Barcodes{
                alt_text: "Scan this QR code",
-               format: "PKBarcodeFormatQR"
+               format: "PKBarcodeFormatQR",
+               message: "Test message"
              } = barcode
 
       encoded = Jason.encode!(barcode)
       assert encoded =~ ~s("altText":"Scan this QR code")
       assert encoded =~ ~s("format":"PKBarcodeFormatQR")
+      assert encoded =~ ~s("message":"Test message")
     end
 
     test "creates a valid Barcodes struct without alt_text" do
-      barcode = Barcodes.new(%{format: "PKBarcodeFormatQR"})
+      barcode = Barcodes.new(%{format: "PKBarcodeFormatQR", message: "Test message"})
 
-      assert %Barcodes{alt_text: nil, format: "PKBarcodeFormatQR"} = barcode
+      assert %Barcodes{alt_text: nil, format: "PKBarcodeFormatQR", message: "Test message"} =
+               barcode
 
       encoded = Jason.encode!(barcode)
-      assert encoded == ~s({"format":"PKBarcodeFormatQR"})
+      assert encoded =~ ~s("format":"PKBarcodeFormatQR")
+      assert encoded =~ ~s("message":"Test message")
+      refute encoded =~ "altText"
     end
 
     test "raises ArgumentError when alt_text is not a string" do
       assert_raise ArgumentError, "alt_text must be a string if provided", fn ->
         Barcodes.new(%{
           alt_text: 123,
-          format: "PKBarcodeFormatQR"
+          format: "PKBarcodeFormatQR",
+          message: "Test message"
         })
       end
     end
@@ -61,22 +68,23 @@ defmodule ExPass.Structs.BarcodesTest do
       ]
 
       for format <- valid_formats do
-        barcode = Barcodes.new(%{format: format})
-        assert %Barcodes{format: ^format} = barcode
+        barcode = Barcodes.new(%{format: format, message: "Test message"})
+        assert %Barcodes{format: ^format, message: "Test message"} = barcode
         encoded = Jason.encode!(barcode)
         assert encoded =~ ~s("format":"#{format}")
+        assert encoded =~ ~s("message":"Test message")
       end
     end
 
     test "raises ArgumentError when format is missing" do
       assert_raise ArgumentError, "format is required", fn ->
-        Barcodes.new(%{})
+        Barcodes.new(%{message: "Test message"})
       end
     end
 
     test "raises ArgumentError when format is not a string" do
       assert_raise ArgumentError, "format must be a string", fn ->
-        Barcodes.new(%{format: 123})
+        Barcodes.new(%{format: 123, message: "Test message"})
       end
     end
 
@@ -84,7 +92,40 @@ defmodule ExPass.Structs.BarcodesTest do
       assert_raise ArgumentError,
                    "Invalid format: InvalidFormat. Supported values are: PKBarcodeFormatQR, PKBarcodeFormatPDF417, PKBarcodeFormatAztec, PKBarcodeFormatCode128",
                    fn ->
-                     Barcodes.new(%{format: "InvalidFormat"})
+                     Barcodes.new(%{format: "InvalidFormat", message: "Test message"})
+                   end
+    end
+  end
+
+  describe "message field" do
+    test "creates a valid Barcodes struct with message" do
+      barcode = Barcodes.new(%{format: "PKBarcodeFormatQR", message: "Test message"})
+      assert %Barcodes{format: "PKBarcodeFormatQR", message: "Test message"} = barcode
+      encoded = Jason.encode!(barcode)
+      assert encoded =~ ~s("message":"Test message")
+    end
+
+    test "raises ArgumentError when message is missing" do
+      assert_raise ArgumentError,
+                   "message is a required field and must be a non-empty string",
+                   fn ->
+                     Barcodes.new(%{format: "PKBarcodeFormatQR"})
+                   end
+    end
+
+    test "raises ArgumentError when message is not a string" do
+      assert_raise ArgumentError,
+                   "message is a required field and must be a non-empty string",
+                   fn ->
+                     Barcodes.new(%{format: "PKBarcodeFormatQR", message: 123})
+                   end
+    end
+
+    test "raises ArgumentError when message is an empty string" do
+      assert_raise ArgumentError,
+                   "message is a required field and must be a non-empty string",
+                   fn ->
+                     Barcodes.new(%{format: "PKBarcodeFormatQR", message: ""})
                    end
     end
   end


### PR DESCRIPTION
## Type of Change
- [x] New feature

## Description
This pull request introduces a new feature to the `Barcodes` struct in the `ExPass` repository. The following changes have been made:

1. **New `message` Field**: A new required field called `message` has been added to the `Barcodes` struct. This field represents the payload or message that will be displayed as a barcode. It must be a non-empty string, and its presence is now enforced when creating a `Barcodes` struct.

2. **Validation**: The `message` field is validated using a new rule that ensures the field is present and contains a valid string. It is now required for struct creation.

3. **Updates to Tests**: The test suite has been updated to cover cases related to the new `message` field. Tests now ensure that the field is enforced, that valid values work correctly, and that invalid or missing values result in appropriate error handling.

## Testing
- **Unit Tests**: 
  - Tests were added to ensure that the `message` field is required and must be a non-empty string.
  - Tests were updated to validate that the `Barcodes` struct cannot be created without this field.
  - Additional tests were included to check valid `message` values, as well as cases where the `message` field is missing, an invalid type, or an empty string.

## Impact
- **Codebase Impact**:
  - The `Barcodes` struct now requires a valid `message` field, which must be a non-empty string.
  - Existing code that constructs `Barcodes` instances without a `message` field will now raise errors.

- **System Behavior**:
  - The new required `message` field strengthens data integrity by ensuring that the content of the barcode is explicitly provided.
  
## Additional Information
- **Breaking Changes**: The addition of a required `message` field represents a breaking change to the `Barcodes` struct. Any code that previously created a `Barcodes` struct without this field will need to be updated to include it.
  
- **Error Handling**: Clear error messages are returned when the `message` field is missing, an invalid type, or an empty string.

## Checklist
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

