### PR TITLE
feat: Add ExPass.Structs.Beacons module for representing Bluetooth Low Energy beacons

### DIFF
--- a/lib/structs/beacons.ex
+++ b/lib/structs/beacons.ex
@@ -1,0 +1,67 @@
+defmodule ExPass.Structs.Beacons do
+  @moduledoc """
+  Represents the identity of a Bluetooth Low Energy beacon used to show a relevant pass.
+
+  ## Fields
+
+  * `:major` - 16-bit unsigned integer. The major identifier of a Bluetooth Low Energy location beacon.
+
+  ## Compatibility
+
+  - iOS 7.0+
+  - iPadOS 6.0+
+  - watchOS 2.0+
+  """
+
+  use TypedStruct
+
+  alias ExPass.Utils.Validators
+
+  typedstruct do
+    field :major, integer()
+  end
+
+  @doc """
+  Creates a new Beacons struct.
+
+  ## Parameters
+
+    * `attrs` - A map of attributes for the Beacons struct. The map can include the following key:
+      * `:major` - (Optional) The major identifier of a Bluetooth Low Energy location beacon.
+
+  ## Returns
+
+    * A new `%Beacons{}` struct.
+
+  ## Examples
+
+      iex> Beacons.new(%{major: 12345})
+      %Beacons{major: 12345}
+
+      iex> Beacons.new(%{})
+      %Beacons{major: nil}
+
+  """
+  @spec new(map()) :: %__MODULE__{}
+  def new(attrs \\ %{}) do
+    attrs = validate(:major, attrs, &Validators.validate_optional_16bit_unsigned_integer/1)
+    struct!(__MODULE__, attrs)
+  end
+
+  defp validate(key, attrs, validator) do
+    case validator.(attrs[key]) do
+      :ok -> attrs
+      {:error, reason} -> raise ArgumentError, "Invalid #{key}: #{reason}"
+    end
+  end
+
+  defimpl Jason.Encoder do
+    def encode(beacons, opts) do
+      beacons
+      |> Map.from_struct()
+      |> Enum.reject(fn {_, v} -> is_nil(v) end)
+      |> Enum.reduce(%{}, fn {k, v}, acc -> Map.put(acc, Atom.to_string(k), v) end)
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/structs/beacons.ex
+++ b/lib/structs/beacons.ex
@@ -35,8 +35,8 @@ defmodule ExPass.Structs.Beacons do
 
   ## Examples
 
-      iex> Beacons.new(%{major: 12345})
-      %Beacons{major: 12345}
+      iex> Beacons.new(%{major: 12_345})
+      %Beacons{major: 12_345}
 
       iex> Beacons.new(%{})
       %Beacons{major: nil}

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -790,6 +790,43 @@ defmodule ExPass.Utils.Validators do
 
   def validate_message_encoding(_), do: {:error, "message_encoding must be a string"}
 
+  @doc """
+  Validates that the given value is a 16-bit unsigned integer (0-65535) or nil.
+
+  ## Examples
+
+      iex> validate_optional_16bit_unsigned_integer(12345)
+      :ok
+
+      iex> validate_optional_16bit_unsigned_integer(0)
+      :ok
+
+      iex> validate_optional_16bit_unsigned_integer(65535)
+      :ok
+
+      iex> validate_optional_16bit_unsigned_integer(nil)
+      :ok
+
+      iex> validate_optional_16bit_unsigned_integer(70000)
+      {:error, "must be a 16-bit unsigned integer (0-65535)"}
+
+      iex> validate_optional_16bit_unsigned_integer(-1)
+      {:error, "must be a 16-bit unsigned integer (0-65535)"}
+
+      iex> validate_optional_16bit_unsigned_integer("invalid")
+      {:error, "must be a 16-bit unsigned integer (0-65535)"}
+
+  """
+  @spec validate_optional_16bit_unsigned_integer(term()) :: :ok | {:error, String.t()}
+  def validate_optional_16bit_unsigned_integer(nil), do: :ok
+
+  def validate_optional_16bit_unsigned_integer(value)
+      when is_integer(value) and value >= 0 and value <= 65535,
+      do: :ok
+
+  def validate_optional_16bit_unsigned_integer(_),
+    do: {:error, "must be a 16-bit unsigned integer (0-65535)"}
+
   defp validate_inclusion(value, valid_values, field_name) do
     if value in valid_values do
       :ok

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -808,24 +808,24 @@ defmodule ExPass.Utils.Validators do
       :ok
 
       iex> validate_optional_16bit_unsigned_integer(70000)
-      {:error, "must be a 16-bit unsigned integer (0-65535)"}
+      {:error, "must be a 16-bit unsigned integer (0-65_535)"}
 
       iex> validate_optional_16bit_unsigned_integer(-1)
-      {:error, "must be a 16-bit unsigned integer (0-65535)"}
+      {:error, "must be a 16-bit unsigned integer (0-65_535)"}
 
       iex> validate_optional_16bit_unsigned_integer("invalid")
-      {:error, "must be a 16-bit unsigned integer (0-65535)"}
+      {:error, "must be a 16-bit unsigned integer (0-65_535)"}
 
   """
   @spec validate_optional_16bit_unsigned_integer(term()) :: :ok | {:error, String.t()}
   def validate_optional_16bit_unsigned_integer(nil), do: :ok
 
   def validate_optional_16bit_unsigned_integer(value)
-      when is_integer(value) and value >= 0 and value <= 65535,
+      when is_integer(value) and value >= 0 and value <= 65_535,
       do: :ok
 
   def validate_optional_16bit_unsigned_integer(_),
-    do: {:error, "must be a 16-bit unsigned integer (0-65535)"}
+    do: {:error, "must be a 16-bit unsigned integer (0-65_535)"}
 
   defp validate_inclusion(value, valid_values, field_name) do
     if value in valid_values do

--- a/test/structs/beacons_test.exs
+++ b/test/structs/beacons_test.exs
@@ -1,0 +1,51 @@
+defmodule ExPass.Structs.BeaconsTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  alias ExPass.Structs.Beacons
+
+  describe "new/0" do
+    test "creates a valid Beacons struct with default arguments" do
+      beacons = Beacons.new()
+      assert %Beacons{major: nil} = beacons
+    end
+  end
+
+  describe "major field" do
+    test "accepts valid major values" do
+      assert %Beacons{major: 0} = Beacons.new(%{major: 0})
+      assert %Beacons{major: 32768} = Beacons.new(%{major: 32768})
+      assert %Beacons{major: 65535} = Beacons.new(%{major: 65535})
+    end
+
+    test "raises ArgumentError for invalid major values" do
+      assert_raise ArgumentError,
+                   "Invalid major: must be a 16-bit unsigned integer (0-65535)",
+                   fn ->
+                     Beacons.new(%{major: 70000})
+                   end
+
+      assert_raise ArgumentError,
+                   "Invalid major: must be a 16-bit unsigned integer (0-65535)",
+                   fn ->
+                     Beacons.new(%{major: -1})
+                   end
+
+      assert_raise ArgumentError,
+                   "Invalid major: must be a 16-bit unsigned integer (0-65535)",
+                   fn ->
+                     Beacons.new(%{major: "invalid"})
+                   end
+    end
+
+    test "encodes to JSON with valid major values" do
+      assert Jason.encode!(Beacons.new(%{major: 0})) == ~s({"major":0})
+      assert Jason.encode!(Beacons.new(%{major: 12345})) == ~s({"major":12345})
+      assert Jason.encode!(Beacons.new(%{major: 65535})) == ~s({"major":65535})
+    end
+
+    test "encodes to JSON without major" do
+      assert Jason.encode!(Beacons.new(%{})) == ~s({})
+    end
+  end
+end

--- a/test/structs/beacons_test.exs
+++ b/test/structs/beacons_test.exs
@@ -14,25 +14,25 @@ defmodule ExPass.Structs.BeaconsTest do
   describe "major field" do
     test "accepts valid major values" do
       assert %Beacons{major: 0} = Beacons.new(%{major: 0})
-      assert %Beacons{major: 32768} = Beacons.new(%{major: 32768})
-      assert %Beacons{major: 65535} = Beacons.new(%{major: 65535})
+      assert %Beacons{major: 32_768} = Beacons.new(%{major: 32_768})
+      assert %Beacons{major: 65_535} = Beacons.new(%{major: 65_535})
     end
 
     test "raises ArgumentError for invalid major values" do
       assert_raise ArgumentError,
-                   "Invalid major: must be a 16-bit unsigned integer (0-65535)",
+                   "Invalid major: must be a 16-bit unsigned integer (0-65_535)",
                    fn ->
-                     Beacons.new(%{major: 70000})
+                     Beacons.new(%{major: 70_000})
                    end
 
       assert_raise ArgumentError,
-                   "Invalid major: must be a 16-bit unsigned integer (0-65535)",
+                   "Invalid major: must be a 16-bit unsigned integer (0-65_535)",
                    fn ->
                      Beacons.new(%{major: -1})
                    end
 
       assert_raise ArgumentError,
-                   "Invalid major: must be a 16-bit unsigned integer (0-65535)",
+                   "Invalid major: must be a 16-bit unsigned integer (0-65_535)",
                    fn ->
                      Beacons.new(%{major: "invalid"})
                    end
@@ -40,8 +40,8 @@ defmodule ExPass.Structs.BeaconsTest do
 
     test "encodes to JSON with valid major values" do
       assert Jason.encode!(Beacons.new(%{major: 0})) == ~s({"major":0})
-      assert Jason.encode!(Beacons.new(%{major: 12345})) == ~s({"major":12345})
-      assert Jason.encode!(Beacons.new(%{major: 65535})) == ~s({"major":65535})
+      assert Jason.encode!(Beacons.new(%{major: 12_345})) == ~s({"major":12345})
+      assert Jason.encode!(Beacons.new(%{major: 65_535})) == ~s({"major":65535})
     end
 
     test "encodes to JSON without major" do


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

This pull request introduces the `ExPass.Structs.Beacons` module, which adds support for representing Bluetooth Low Energy (BLE) beacons in the system. The main feature is the new `:major` field, a 16-bit unsigned integer representing the beacon’s major identifier. The module provides the `Beacons.new/1` function for creating a new beacon struct and includes validation for the `:major` field via the `validate_optional_16bit_unsigned_integer/1` function.

The `Beacons` struct implements the `Jason.Encoder` protocol, allowing it to be serialized into JSON format. Additionally, test cases for struct creation, validation, and encoding have been added to ensure correctness.

## Testing

- New tests have been added to validate the `Beacons` struct, including:
  - Validation of valid and invalid `:major` field values.
  - JSON encoding with and without the `:major` field.
- Edge cases around the 16-bit integer constraints (0-65535) for the `:major` field have been tested.
  
## Impact

- Extends the ExPass system with support for BLE beacons.
- Minor performance impact due to additional validation logic.
- Potential security considerations related to beacon validation, requiring secure handling of the beacon’s major identifier.

## Additional Information

No new dependencies have been introduced, and all existing functionality remains intact. This update is compatible with iOS 7.0+, iPadOS 6.0+, and watchOS 2.0+.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

