### PR TITLE
feat: Add Locations struct with altitude field validation

### DIFF
--- a/lib/structs/locations.ex
+++ b/lib/structs/locations.ex
@@ -1,0 +1,82 @@
+defmodule ExPass.Structs.Locations do
+  @moduledoc """
+  Represents a location that the system uses to show a relevant pass.
+
+  ## Fields
+
+  * `:altitude` - The altitude, in meters, of the location. This is a double-precision floating-point number.
+
+  ## Compatibility
+
+  - iOS 6.0+
+  - iPadOS 6.0+
+  - watchOS 2.0+
+  """
+
+  use TypedStruct
+
+  alias ExPass.Utils.Converter
+  alias ExPass.Utils.Validators
+
+  typedstruct do
+    field :altitude, float()
+  end
+
+  @doc """
+  Creates a new Locations struct.
+
+  ## Parameters
+
+    * `attrs` - A map of attributes for the Locations struct. The map can include the following key:
+      * `:altitude` - (Optional) The altitude, in meters, of the location. This should be a double-precision floating-point number.
+
+  ## Returns
+
+    * A new `%Locations{}` struct.
+
+  ## Examples
+
+      iex> Locations.new(%{altitude: 100.5})
+      %Locations{altitude: 100.5}
+
+      iex> Locations.new(%{})
+      %Locations{altitude: nil}
+
+      iex> Locations.new(%{altitude: -50.75})
+      %Locations{altitude: -50.75}
+
+      iex> Locations.new(%{altitude: "invalid"})
+      ** (ArgumentError) altitude must be a float
+
+  """
+  @spec new(map()) :: %__MODULE__{}
+  def new(attrs \\ %{}) do
+    attrs =
+      attrs
+      |> validate(:altitude, &Validators.validate_optional_float(&1, :altitude))
+
+    struct!(__MODULE__, attrs)
+  end
+
+  defp validate(attrs, key, validator) do
+    case validator.(attrs[key]) do
+      :ok ->
+        attrs
+
+      {:error, reason} ->
+        raise ArgumentError, reason
+    end
+  end
+
+  defimpl Jason.Encoder do
+    def encode(field_content, opts) do
+      field_content
+      |> Map.from_struct()
+      |> Enum.reduce(%{}, fn
+        {_k, nil}, acc -> acc
+        {k, v}, acc -> Map.put(acc, Converter.camelize_key(k), v)
+      end)
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -874,6 +874,44 @@ defmodule ExPass.Utils.Validators do
 
   def validate_uuid(_), do: {:error, "proximity_UUID must be a valid UUID string"}
 
+  @doc """
+  Validates that the given value is a float or nil.
+
+  ## Parameters
+
+    * `value` - The value to validate.
+    * `field_name` - The name of the field being validated, used in error messages.
+
+  ## Examples
+
+      iex> validate_optional_float(42.5, :altitude)
+      :ok
+
+      iex> validate_optional_float(0.0, :altitude)
+      :ok
+
+      iex> validate_optional_float(-10.75, :altitude)
+      :ok
+
+      iex> validate_optional_float(nil, :altitude)
+      :ok
+
+      iex> validate_optional_float(42, :altitude)
+      {:error, "altitude must be a float"}
+
+      iex> validate_optional_float("invalid", :altitude)
+      {:error, "altitude must be a float"}
+
+  """
+  @spec validate_optional_float(term(), atom()) :: :ok | {:error, String.t()}
+  def validate_optional_float(nil, _field_name), do: :ok
+  def validate_optional_float(value, _field_name) when is_float(value), do: :ok
+
+  def validate_optional_float(value, field_name) when is_integer(value),
+    do: {:error, "#{field_name} must be a float"}
+
+  def validate_optional_float(_value, field_name), do: {:error, "#{field_name} must be a float"}
+
   defp validate_inclusion(value, valid_values, field_name) do
     if value in valid_values do
       :ok

--- a/test/structs/field_content_test.exs
+++ b/test/structs/field_content_test.exs
@@ -6,8 +6,8 @@ defmodule ExPass.Structs.FieldContentTest do
 
   doctest FieldContent
 
-  describe "new/1" do
-    test "new/1 raises ArgumentError when called with no arguments" do
+  describe "new/0" do
+    test "new/0 raises ArgumentError when called with no arguments" do
       assert_raise ArgumentError, "key is a required field and must be a non-empty string", fn ->
         FieldContent.new()
       end

--- a/test/structs/locations_test.exs
+++ b/test/structs/locations_test.exs
@@ -1,0 +1,58 @@
+defmodule ExPass.Structs.LocationsTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  alias ExPass.Structs.Locations
+
+  describe "new/0" do
+    test "creates a valid Locations struct with default values" do
+      assert %Locations{altitude: nil} = location = Locations.new()
+      assert "{}" = Jason.encode!(location)
+    end
+  end
+
+  describe "new/1 with altitude field" do
+    test "creates a valid Locations struct with altitude field" do
+      params = %{altitude: 100.5}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.altitude == 100.5
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("altitude":100.5)
+    end
+
+    test "creates a valid Locations struct with altitude field set to 0" do
+      params = %{altitude: 0.0}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.altitude == 0.0
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("altitude":0.0)
+    end
+
+    test "creates a valid Locations struct with altitude field set to negative value" do
+      params = %{altitude: -50.75}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.altitude == -50.75
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("altitude":-50.75)
+    end
+
+    test "returns error for invalid altitude (integer value)" do
+      params = %{altitude: 100}
+
+      assert_raise ArgumentError, "altitude must be a float", fn ->
+        Locations.new(params)
+      end
+    end
+
+    test "returns error for invalid altitude (non-numeric value)" do
+      params = %{altitude: "100.5"}
+
+      assert_raise ArgumentError, "altitude must be a float", fn ->
+        Locations.new(params)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Title

Add `Locations` Struct with Altitude Field and Validation Logic

## Type of Change

- [x] New feature

## Description

This PR introduces a new `Locations` struct to the ExPass system to represent a geographic location. The struct includes an `altitude` field, which is validated to ensure that it is either a float or nil. The change includes a corresponding validation function and a set of tests to ensure that the `altitude` field behaves correctly under different scenarios.

A validator function `validate_optional_float/2` has been added to ensure that only floats are accepted for the altitude value.

## Testing

Tests have been added for the new `Locations` struct to ensure the following:
- The struct can be created with default values.
- Valid floats (including negative and zero values) are accepted for the altitude field.
- Invalid values (such as integers and strings) raise an appropriate error.
- The `validate_optional_float/2` function has been tested to ensure it properly validates or rejects values.

## Impact

The introduction of the `Locations` struct enhances the system’s ability to handle location-specific passes. It does not directly impact existing code outside of the location-based functionality. Future code that involves location data may need to account for altitude, and tests should ensure backward compatibility with other parts of the system.

## Additional Information

No additional information is required.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

