### PR TITLE
feat: Add latitude field validation to Locations struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ end
 |  | `Pass.beacons.minor` | [#61](https://github.com/njausteve/ex_pass/issues/61) | ✅ |
 |  | `Pass.beacons.proximityUUID` | [#62](https://github.com/njausteve/ex_pass/issues/62) | ✅ |
 |  | `Pass.beacons.relevantText` | [#63](https://github.com/njausteve/ex_pass/issues/63) | ✅ |
-| `Pass.Locations` | `Pass.locations.altitude` | [#89](https://github.com/njausteve/ex_pass/issues/89) | `todo` |
-|  | `Pass.locations.latitude` | [#90](https://github.com/njausteve/ex_pass/issues/90) | `todo` |
+| `Pass.Locations` | `Pass.locations.altitude` | [#89](https://github.com/njausteve/ex_pass/issues/89) | ✅ |
+|  | `Pass.locations.latitude` | [#90](https://github.com/njausteve/ex_pass/issues/90) | ✅ |
 |  | `Pass.locations.longitude` | [#91](https://github.com/njausteve/ex_pass/issues/91) | `todo` |
 |  | `Pass.locations.relevantText` | [#92](https://github.com/njausteve/ex_pass/issues/92) | `todo` |
 | `Pass.NFC` | `Pass.nfc.encryptionPublicKey` | [#93](https://github.com/njausteve/ex_pass/issues/93) | `todo` |

--- a/lib/structs/locations.ex
+++ b/lib/structs/locations.ex
@@ -5,6 +5,7 @@ defmodule ExPass.Structs.Locations do
   ## Fields
 
   * `:altitude` - The altitude, in meters, of the location. This is a double-precision floating-point number.
+  * `:latitude` - (Required) The latitude, in degrees, of the location. This is a double-precision floating-point number between -90 and 90.
 
   ## Compatibility
 
@@ -20,6 +21,7 @@ defmodule ExPass.Structs.Locations do
 
   typedstruct do
     field :altitude, float()
+    field :latitude, float(), enforce: true
   end
 
   @doc """
@@ -27,8 +29,9 @@ defmodule ExPass.Structs.Locations do
 
   ## Parameters
 
-    * `attrs` - A map of attributes for the Locations struct. The map can include the following key:
+    * `attrs` - A map of attributes for the Locations struct. The map can include the following keys:
       * `:altitude` - (Optional) The altitude, in meters, of the location. This should be a double-precision floating-point number.
+      * `:latitude` - (Required) The latitude, in degrees, of the location. This should be a double-precision floating-point number between -90 and 90.
 
   ## Returns
 
@@ -36,17 +39,23 @@ defmodule ExPass.Structs.Locations do
 
   ## Examples
 
-      iex> Locations.new(%{altitude: 100.5})
-      %Locations{altitude: 100.5}
+      iex> Locations.new(%{latitude: 37.7749})
+      %Locations{altitude: nil, latitude: 37.7749}
+
+      iex> Locations.new(%{altitude: 100.5, latitude: 37.7749})
+      %Locations{altitude: 100.5, latitude: 37.7749}
+
+      iex> Locations.new(%{latitude: -50.75})
+      %Locations{altitude: nil, latitude: -50.75}
+
+      iex> Locations.new(%{latitude: "invalid"})
+      ** (ArgumentError) latitude must be a float
 
       iex> Locations.new(%{})
-      %Locations{altitude: nil}
+      ** (ArgumentError) latitude is required
 
-      iex> Locations.new(%{altitude: -50.75})
-      %Locations{altitude: -50.75}
-
-      iex> Locations.new(%{altitude: "invalid"})
-      ** (ArgumentError) altitude must be a float
+      iex> Locations.new(%{latitude: 91.0})
+      ** (ArgumentError) latitude must be between -90 and 90
 
   """
   @spec new(map()) :: %__MODULE__{}
@@ -54,6 +63,7 @@ defmodule ExPass.Structs.Locations do
     attrs =
       attrs
       |> validate(:altitude, &Validators.validate_optional_float(&1, :altitude))
+      |> validate(:latitude, &Validators.validate_latitude(&1, :latitude))
 
     struct!(__MODULE__, attrs)
   end

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -906,11 +906,57 @@ defmodule ExPass.Utils.Validators do
   @spec validate_optional_float(term(), atom()) :: :ok | {:error, String.t()}
   def validate_optional_float(nil, _field_name), do: :ok
   def validate_optional_float(value, _field_name) when is_float(value), do: :ok
+  def validate_optional_float(_, field_name), do: {:error, "#{field_name} must be a float"}
 
-  def validate_optional_float(value, field_name) when is_integer(value),
+  @doc """
+  Validates that the given value is a float within the range of -90 to 90 (inclusive).
+
+  ## Parameters
+
+    * `value` - The value to validate.
+    * `field_name` - The name of the field being validated as an atom.
+
+  ## Returns
+
+    * `:ok` if the value is a valid float within the range.
+    * `{:error, reason}` if the value is not a valid float or is outside the range.
+
+  ## Examples
+
+      iex> validate_latitude(37.7749, :latitude)
+      :ok
+
+      iex> validate_latitude(-90.0, :latitude)
+      :ok
+
+      iex> validate_latitude(90.0, :latitude)
+      :ok
+
+      iex> validate_latitude(90.1, :latitude)
+      {:error, "latitude must be between -90 and 90"}
+
+      iex> validate_latitude(-90.1, :latitude)
+      {:error, "latitude must be between -90 and 90"}
+
+      iex> validate_latitude("37.7749", :latitude)
+      {:error, "latitude must be a float"}
+
+      iex> validate_latitude(nil, :latitude)
+      {:error, "latitude is a required field and cannot be nil"}
+
+  """
+  @spec validate_latitude(float() | nil, atom()) :: :ok | {:error, String.t()}
+  def validate_latitude(nil, field_name),
+    do: {:error, "#{field_name} is a required field and cannot be nil"}
+
+  def validate_latitude(value, _field_name) when is_float(value) and value >= -90 and value <= 90,
+    do: :ok
+
+  def validate_latitude(value, field_name) when is_float(value),
+    do: {:error, "#{field_name} must be between -90 and 90"}
+
+  def validate_latitude(_value, field_name),
     do: {:error, "#{field_name} must be a float"}
-
-  def validate_optional_float(_value, field_name), do: {:error, "#{field_name} must be a float"}
 
   defp validate_inclusion(value, valid_values, field_name) do
     if value in valid_values do

--- a/test/structs/locations_test.exs
+++ b/test/structs/locations_test.exs
@@ -5,42 +5,49 @@ defmodule ExPass.Structs.LocationsTest do
   alias ExPass.Structs.Locations
 
   describe "new/0" do
-    test "creates a valid Locations struct with default values" do
-      assert %Locations{altitude: nil} = location = Locations.new()
-      assert "{}" = Jason.encode!(location)
+    test "throws exception when no latitude is provided" do
+      assert_raise ArgumentError, "latitude is a required field and cannot be nil", fn ->
+        Locations.new()
+      end
     end
   end
 
   describe "new/1 with altitude field" do
     test "creates a valid Locations struct with altitude field" do
-      params = %{altitude: 100.5}
+      params = %{altitude: 100.5, latitude: 37.7749}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.altitude == 100.5
+      assert location.latitude == 37.7749
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("altitude":100.5)
+      assert encoded =~ ~s("latitude":37.7749)
     end
 
     test "creates a valid Locations struct with altitude field set to 0" do
-      params = %{altitude: 0.0}
+      params = %{altitude: 0.0, latitude: -45.0}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.altitude == 0.0
+      assert location.latitude == -45.0
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("altitude":0.0)
+      assert encoded =~ ~s("latitude":-45.0)
     end
 
     test "creates a valid Locations struct with altitude field set to negative value" do
-      params = %{altitude: -50.75}
+      params = %{altitude: -50.75, latitude: 90.0}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.altitude == -50.75
+      assert location.latitude == 90.0
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("altitude":-50.75)
+      assert encoded =~ ~s("latitude":90.0)
     end
 
     test "returns error for invalid altitude (integer value)" do
-      params = %{altitude: 100}
+      params = %{altitude: 100, latitude: 0.0}
 
       assert_raise ArgumentError, "altitude must be a float", fn ->
         Locations.new(params)
@@ -48,9 +55,70 @@ defmodule ExPass.Structs.LocationsTest do
     end
 
     test "returns error for invalid altitude (non-numeric value)" do
-      params = %{altitude: "100.5"}
+      params = %{altitude: "100.5", latitude: 0.0}
 
       assert_raise ArgumentError, "altitude must be a float", fn ->
+        Locations.new(params)
+      end
+    end
+  end
+
+  describe "new/1 with latitude field" do
+    test "creates a valid Locations struct with latitude field" do
+      params = %{latitude: 37.7749}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.latitude == 37.7749
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("latitude":37.7749)
+    end
+
+    test "creates a valid Locations struct with latitude field at minimum value" do
+      params = %{latitude: -90.0}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.latitude == -90.0
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("latitude":-90.0)
+    end
+
+    test "creates a valid Locations struct with latitude field at maximum value" do
+      params = %{latitude: 90.0}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.latitude == 90.0
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("latitude":90.0)
+    end
+
+    test "returns error for invalid latitude (below minimum)" do
+      params = %{latitude: -90.1}
+
+      assert_raise ArgumentError, "latitude must be between -90 and 90", fn ->
+        Locations.new(params)
+      end
+    end
+
+    test "returns error for invalid latitude (above maximum)" do
+      params = %{latitude: 90.1}
+
+      assert_raise ArgumentError, "latitude must be between -90 and 90", fn ->
+        Locations.new(params)
+      end
+    end
+
+    test "returns error for invalid latitude (non-float value)" do
+      params = %{latitude: "37.7749"}
+
+      assert_raise ArgumentError, "latitude must be a float", fn ->
+        Locations.new(params)
+      end
+    end
+
+    test "returns error when latitude is missing" do
+      params = %{}
+
+      assert_raise ArgumentError, "latitude is a required field and cannot be nil", fn ->
         Locations.new(params)
       end
     end


### PR DESCRIPTION
## Title

Add Latitude Validation to Locations Struct and Enhance Altitude Handling

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This pull request adds a new `latitude` field to the `Locations` struct in the ExPass system, making it a required field. The `latitude` must be a float between -90 and 90 degrees. The existing `altitude` field remains optional but is validated to ensure it is a float if provided.

The changes include validation functions to enforce these constraints, with appropriate error messages for invalid inputs. Unit tests have been added to verify the correct behavior of both fields.

## Testing

Unit tests have been added to cover the following scenarios:
- Valid latitude and altitude values are accepted.
- Latitude values outside the valid range of -90 to 90 degrees raise appropriate errors.
- Non-float values for both latitude and altitude raise errors.
- Latitude is now a required field, and missing it raises an error.

## Impact

This change will enforce stricter validation on the `Locations` struct, requiring latitude to always be provided. This could lead to breaking changes if existing code does not provide latitude values. Developers will need to ensure their code accounts for this new requirement.

No significant performance or security implications are expected, but the stricter validation improves data integrity and prevents invalid geographic data from being processed.

## Additional Information

No additional information is required.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.


