### PR TITLE
91 add longitude field for locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ end
 |  | `Pass.beacons.relevantText` | [#63](https://github.com/njausteve/ex_pass/issues/63) | ✅ |
 | `Pass.Locations` | `Pass.locations.altitude` | [#89](https://github.com/njausteve/ex_pass/issues/89) | ✅ |
 |  | `Pass.locations.latitude` | [#90](https://github.com/njausteve/ex_pass/issues/90) | ✅ |
-|  | `Pass.locations.longitude` | [#91](https://github.com/njausteve/ex_pass/issues/91) | `todo` |
+|  | `Pass.locations.longitude` | [#91](https://github.com/njausteve/ex_pass/issues/91) | ✅ |
 |  | `Pass.locations.relevantText` | [#92](https://github.com/njausteve/ex_pass/issues/92) | `todo` |
 | `Pass.NFC` | `Pass.nfc.encryptionPublicKey` | [#93](https://github.com/njausteve/ex_pass/issues/93) | `todo` |
 |  | `Pass.nfc.message` | [#94](https://github.com/njausteve/ex_pass/issues/94) | `todo` |

--- a/lib/structs/locations.ex
+++ b/lib/structs/locations.ex
@@ -6,6 +6,7 @@ defmodule ExPass.Structs.Locations do
 
   * `:altitude` - The altitude, in meters, of the location. This is a double-precision floating-point number.
   * `:latitude` - (Required) The latitude, in degrees, of the location. This is a double-precision floating-point number between -90 and 90.
+  * `:longitude` - (Required) The longitude, in degrees, of the location. This is a double-precision floating-point number between -180 and 180.
 
   ## Compatibility
 
@@ -22,6 +23,7 @@ defmodule ExPass.Structs.Locations do
   typedstruct do
     field :altitude, float()
     field :latitude, float(), enforce: true
+    field :longitude, float(), enforce: true
   end
 
   @doc """
@@ -32,6 +34,7 @@ defmodule ExPass.Structs.Locations do
     * `attrs` - A map of attributes for the Locations struct. The map can include the following keys:
       * `:altitude` - (Optional) The altitude, in meters, of the location. This should be a double-precision floating-point number.
       * `:latitude` - (Required) The latitude, in degrees, of the location. This should be a double-precision floating-point number between -90 and 90.
+      * `:longitude` - (Required) The longitude, in degrees, of the location. This should be a double-precision floating-point number between -180 and 180.
 
   ## Returns
 
@@ -39,23 +42,26 @@ defmodule ExPass.Structs.Locations do
 
   ## Examples
 
-      iex> Locations.new(%{latitude: 37.7749})
-      %Locations{altitude: nil, latitude: 37.7749}
+      iex> Locations.new(%{latitude: 37.7749, longitude: -122.4194})
+      %Locations{altitude: nil, latitude: 37.7749, longitude: -122.4194}
 
-      iex> Locations.new(%{altitude: 100.5, latitude: 37.7749})
-      %Locations{altitude: 100.5, latitude: 37.7749}
+      iex> Locations.new(%{altitude: 100.5, latitude: 37.7749, longitude: -122.4194})
+      %Locations{altitude: 100.5, latitude: 37.7749, longitude: -122.4194}
 
-      iex> Locations.new(%{latitude: -50.75})
-      %Locations{altitude: nil, latitude: -50.75}
+      iex> Locations.new(%{latitude: -50.75, longitude: 165.3})
+      %Locations{altitude: nil, latitude: -50.75, longitude: 165.3}
 
-      iex> Locations.new(%{latitude: "invalid"})
+      iex> Locations.new(%{latitude: "invalid", longitude: 0.0})
       ** (ArgumentError) latitude must be a float
 
-      iex> Locations.new(%{})
-      ** (ArgumentError) latitude is required
+      iex> Locations.new(%{latitude: 37.7749})
+      ** (ArgumentError) longitude is required
 
-      iex> Locations.new(%{latitude: 91.0})
+      iex> Locations.new(%{latitude: 91.0, longitude: 0.0})
       ** (ArgumentError) latitude must be between -90 and 90
+
+      iex> Locations.new(%{latitude: 37.7749, longitude: 181.0})
+      ** (ArgumentError) longitude must be between -180 and 180
 
   """
   @spec new(map()) :: %__MODULE__{}
@@ -64,6 +70,7 @@ defmodule ExPass.Structs.Locations do
       attrs
       |> validate(:altitude, &Validators.validate_optional_float(&1, :altitude))
       |> validate(:latitude, &Validators.validate_latitude(&1, :latitude))
+      |> validate(:longitude, &Validators.validate_longitude(&1, :longitude))
 
     struct!(__MODULE__, attrs)
   end

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -958,6 +958,53 @@ defmodule ExPass.Utils.Validators do
   def validate_latitude(_value, field_name),
     do: {:error, "#{field_name} must be a float"}
 
+  @doc """
+  Validates that the given value is a float within the range of -180 to 180 (inclusive).
+
+  ## Parameters
+
+    * `value` - The value to validate.
+    * `field_name` - The name of the field being validated as an atom.
+
+  ## Returns
+
+    * `:ok` if the value is a valid float within the range.
+    * `{:error, reason}` if the value is not a valid float or is outside the range.
+
+  ## Examples
+
+      iex> validate_longitude(122.4194, :longitude)
+      :ok
+
+      iex> validate_longitude(-180.0, :longitude)
+      :ok
+
+      iex> validate_longitude(180.0, :longitude)
+      :ok
+
+      iex> validate_longitude(180.1, :longitude)
+      {:error, "longitude must be between -180 and 180"}
+
+      iex> validate_longitude(-180.1, :longitude)
+      {:error, "longitude must be between -180 and 180"}
+
+      iex> validate_longitude("122.4194", :longitude)
+      {:error, "longitude must be a float"}
+
+  """
+  @spec validate_longitude(float() | nil, atom()) :: :ok | {:error, String.t()}
+  def validate_longitude(nil, field_name),
+    do: {:error, "#{field_name} is a required field and cannot be nil"}
+
+  def validate_longitude(value, _field_name) when is_float(value) and value >= -180 and value <= 180,
+    do: :ok
+
+  def validate_longitude(value, field_name) when is_float(value),
+    do: {:error, "#{field_name} must be between -180 and 180"}
+
+  def validate_longitude(_value, field_name),
+    do: {:error, "#{field_name} must be a float"}
+
   defp validate_inclusion(value, valid_values, field_name) do
     if value in valid_values do
       :ok

--- a/lib/utils/validators.ex
+++ b/lib/utils/validators.ex
@@ -996,8 +996,9 @@ defmodule ExPass.Utils.Validators do
   def validate_longitude(nil, field_name),
     do: {:error, "#{field_name} is a required field and cannot be nil"}
 
-  def validate_longitude(value, _field_name) when is_float(value) and value >= -180 and value <= 180,
-    do: :ok
+  def validate_longitude(value, _field_name)
+      when is_float(value) and value >= -180 and value <= 180,
+      do: :ok
 
   def validate_longitude(value, field_name) when is_float(value),
     do: {:error, "#{field_name} must be between -180 and 180"}

--- a/test/structs/locations_test.exs
+++ b/test/structs/locations_test.exs
@@ -10,44 +10,56 @@ defmodule ExPass.Structs.LocationsTest do
         Locations.new()
       end
     end
+
+    test "throws exception when no longitude is provided" do
+      assert_raise ArgumentError, "longitude is a required field and cannot be nil", fn ->
+        Locations.new(%{latitude: 0.0})
+      end
+    end
   end
 
   describe "new/1 with altitude field" do
     test "creates a valid Locations struct with altitude field" do
-      params = %{altitude: 100.5, latitude: 37.7749}
+      params = %{altitude: 100.5, latitude: 37.7749, longitude: -122.4194}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.altitude == 100.5
       assert location.latitude == 37.7749
+      assert location.longitude == -122.4194
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("altitude":100.5)
       assert encoded =~ ~s("latitude":37.7749)
+      assert encoded =~ ~s("longitude":-122.4194)
     end
 
     test "creates a valid Locations struct with altitude field set to 0" do
-      params = %{altitude: 0.0, latitude: -45.0}
+      params = %{altitude: 0.0, latitude: -45.0, longitude: 170.5}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.altitude == 0.0
       assert location.latitude == -45.0
+      assert location.longitude == 170.5
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("altitude":0.0)
       assert encoded =~ ~s("latitude":-45.0)
+      assert encoded =~ ~s("longitude":170.5)
     end
 
     test "creates a valid Locations struct with altitude field set to negative value" do
-      params = %{altitude: -50.75, latitude: 90.0}
+      params = %{altitude: -50.75, latitude: 90.0, longitude: 0.0}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.altitude == -50.75
       assert location.latitude == 90.0
+      assert location.longitude == 0.0
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("altitude":-50.75)
       assert encoded =~ ~s("latitude":90.0)
+      assert encoded =~ ~s("longitude":0.0)
     end
 
     test "returns error for invalid altitude (integer value)" do
-      params = %{altitude: 100, latitude: 0.0}
+      params = %{altitude: 100, latitude: 0.0, longitude: 0.0}
 
       assert_raise ArgumentError, "altitude must be a float", fn ->
         Locations.new(params)
@@ -55,7 +67,7 @@ defmodule ExPass.Structs.LocationsTest do
     end
 
     test "returns error for invalid altitude (non-numeric value)" do
-      params = %{altitude: "100.5", latitude: 0.0}
+      params = %{altitude: "100.5", latitude: 0.0, longitude: 0.0}
 
       assert_raise ArgumentError, "altitude must be a float", fn ->
         Locations.new(params)
@@ -65,34 +77,40 @@ defmodule ExPass.Structs.LocationsTest do
 
   describe "new/1 with latitude field" do
     test "creates a valid Locations struct with latitude field" do
-      params = %{latitude: 37.7749}
+      params = %{latitude: 37.7749, longitude: -122.4194}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.latitude == 37.7749
+      assert location.longitude == -122.4194
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("latitude":37.7749)
+      assert encoded =~ ~s("longitude":-122.4194)
     end
 
     test "creates a valid Locations struct with latitude field at minimum value" do
-      params = %{latitude: -90.0}
+      params = %{latitude: -90.0, longitude: 0.0}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.latitude == -90.0
+      assert location.longitude == 0.0
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("latitude":-90.0)
+      assert encoded =~ ~s("longitude":0.0)
     end
 
     test "creates a valid Locations struct with latitude field at maximum value" do
-      params = %{latitude: 90.0}
+      params = %{latitude: 90.0, longitude: 180.0}
 
       assert %Locations{} = location = Locations.new(params)
       assert location.latitude == 90.0
+      assert location.longitude == 180.0
       encoded = Jason.encode!(location)
       assert encoded =~ ~s("latitude":90.0)
+      assert encoded =~ ~s("longitude":180.0)
     end
 
     test "returns error for invalid latitude (below minimum)" do
-      params = %{latitude: -90.1}
+      params = %{latitude: -90.1, longitude: 0.0}
 
       assert_raise ArgumentError, "latitude must be between -90 and 90", fn ->
         Locations.new(params)
@@ -100,7 +118,7 @@ defmodule ExPass.Structs.LocationsTest do
     end
 
     test "returns error for invalid latitude (above maximum)" do
-      params = %{latitude: 90.1}
+      params = %{latitude: 90.1, longitude: 0.0}
 
       assert_raise ArgumentError, "latitude must be between -90 and 90", fn ->
         Locations.new(params)
@@ -108,7 +126,7 @@ defmodule ExPass.Structs.LocationsTest do
     end
 
     test "returns error for invalid latitude (non-float value)" do
-      params = %{latitude: "37.7749"}
+      params = %{latitude: "37.7749", longitude: 0.0}
 
       assert_raise ArgumentError, "latitude must be a float", fn ->
         Locations.new(params)
@@ -116,9 +134,76 @@ defmodule ExPass.Structs.LocationsTest do
     end
 
     test "returns error when latitude is missing" do
-      params = %{}
+      params = %{longitude: 0.0}
 
       assert_raise ArgumentError, "latitude is a required field and cannot be nil", fn ->
+        Locations.new(params)
+      end
+    end
+  end
+
+  describe "new/1 with longitude field" do
+    test "creates a valid Locations struct with longitude field" do
+      params = %{latitude: 37.7749, longitude: -122.4194}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.latitude == 37.7749
+      assert location.longitude == -122.4194
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("latitude":37.7749)
+      assert encoded =~ ~s("longitude":-122.4194)
+    end
+
+    test "creates a valid Locations struct with longitude field at minimum value" do
+      params = %{latitude: 0.0, longitude: -180.0}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.latitude == 0.0
+      assert location.longitude == -180.0
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("latitude":0.0)
+      assert encoded =~ ~s("longitude":-180.0)
+    end
+
+    test "creates a valid Locations struct with longitude field at maximum value" do
+      params = %{latitude: 0.0, longitude: 180.0}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.latitude == 0.0
+      assert location.longitude == 180.0
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("latitude":0.0)
+      assert encoded =~ ~s("longitude":180.0)
+    end
+
+    test "returns error for invalid longitude (below minimum)" do
+      params = %{latitude: 0.0, longitude: -180.1}
+
+      assert_raise ArgumentError, "longitude must be between -180 and 180", fn ->
+        Locations.new(params)
+      end
+    end
+
+    test "returns error for invalid longitude (above maximum)" do
+      params = %{latitude: 0.0, longitude: 180.1}
+
+      assert_raise ArgumentError, "longitude must be between -180 and 180", fn ->
+        Locations.new(params)
+      end
+    end
+
+    test "returns error for invalid longitude (non-float value)" do
+      params = %{latitude: 0.0, longitude: "-122.4194"}
+
+      assert_raise ArgumentError, "longitude must be a float", fn ->
+        Locations.new(params)
+      end
+    end
+
+    test "returns error when longitude is missing" do
+      params = %{latitude: 0.0}
+
+      assert_raise ArgumentError, "longitude is a required field and cannot be nil", fn ->
         Locations.new(params)
       end
     end


### PR DESCRIPTION
## Title

Add Longitude Validation to Locations Struct and Update Geographic Constraints

## Type of Change

- [x] New feature

## Description

This pull request introduces a new `longitude` field to the `Locations` struct in the ExPass system. Longitude is a required field and must be a float between -180 and 180 degrees. The existing `latitude` field is still validated between -90 and 90 degrees. 

Validation functions for both latitude and longitude have been added, ensuring that only valid geographic coordinates are accepted.

The README has been updated to reflect the completion of the longitude field in the project’s progress.

## Testing

Unit tests have been updated to verify the following:
- Valid longitude values (between -180 and 180) are accepted.
- Invalid longitude values (outside the range or non-float values) raise appropriate errors.
- The `Locations` struct requires both latitude and longitude, and missing either will raise an error.

## Impact

The new `longitude` field is required for creating a `Locations` struct, meaning any code that previously created a `Locations` struct without specifying longitude will now fail. Developers will need to update their code to include longitude when using this struct.

## Additional Information

No additional information is required.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

