### PR TITLE
92 add relevanttext field for locations

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ end
 | `Pass.Locations` | `Pass.locations.altitude` | [#89](https://github.com/njausteve/ex_pass/issues/89) | ✅ |
 |  | `Pass.locations.latitude` | [#90](https://github.com/njausteve/ex_pass/issues/90) | ✅ |
 |  | `Pass.locations.longitude` | [#91](https://github.com/njausteve/ex_pass/issues/91) | ✅ |
-|  | `Pass.locations.relevantText` | [#92](https://github.com/njausteve/ex_pass/issues/92) | `todo` |
+|  | `Pass.locations.relevantText` | [#92](https://github.com/njausteve/ex_pass/issues/92) | ✅ |
 | `Pass.NFC` | `Pass.nfc.encryptionPublicKey` | [#93](https://github.com/njausteve/ex_pass/issues/93) | `todo` |
 |  | `Pass.nfc.message` | [#94](https://github.com/njausteve/ex_pass/issues/94) | `todo` |
 |  | `Pass.nfc.requiresAuthentication` | [#95](https://github.com/njausteve/ex_pass/issues/95) | `todo` |

--- a/lib/structs/beacons.ex
+++ b/lib/structs/beacons.ex
@@ -68,6 +68,7 @@ defmodule ExPass.Structs.Beacons do
   def new(attrs \\ %{}) do
     attrs =
       attrs
+      |> Converter.trim_string_values()
       |> validate(:major, &Validators.validate_optional_16bit_unsigned_integer(&1, :major))
       |> validate(:minor, &Validators.validate_optional_16bit_unsigned_integer(&1, :minor))
       |> validate(:proximity_UUID, &Validators.validate_uuid/1)

--- a/lib/structs/locations.ex
+++ b/lib/structs/locations.ex
@@ -7,6 +7,7 @@ defmodule ExPass.Structs.Locations do
   * `:altitude` - The altitude, in meters, of the location. This is a double-precision floating-point number.
   * `:latitude` - (Required) The latitude, in degrees, of the location. This is a double-precision floating-point number between -90 and 90.
   * `:longitude` - (Required) The longitude, in degrees, of the location. This is a double-precision floating-point number between -180 and 180.
+  * `:relevant_text` - The text to display on the lock screen when the pass is relevant. For example, a description of a nearby location, such as "Store nearby on 1st and Main".
 
   ## Compatibility
 
@@ -24,6 +25,7 @@ defmodule ExPass.Structs.Locations do
     field :altitude, float()
     field :latitude, float(), enforce: true
     field :longitude, float(), enforce: true
+    field :relevant_text, String.t()
   end
 
   @doc """
@@ -35,6 +37,7 @@ defmodule ExPass.Structs.Locations do
       * `:altitude` - (Optional) The altitude, in meters, of the location. This should be a double-precision floating-point number.
       * `:latitude` - (Required) The latitude, in degrees, of the location. This should be a double-precision floating-point number between -90 and 90.
       * `:longitude` - (Required) The longitude, in degrees, of the location. This should be a double-precision floating-point number between -180 and 180.
+      * `:relevant_text` - (Optional) The text to display on the lock screen when the pass is relevant.
 
   ## Returns
 
@@ -43,13 +46,13 @@ defmodule ExPass.Structs.Locations do
   ## Examples
 
       iex> Locations.new(%{latitude: 37.7749, longitude: -122.4194})
-      %Locations{altitude: nil, latitude: 37.7749, longitude: -122.4194}
+      %Locations{altitude: nil, latitude: 37.7749, longitude: -122.4194, relevant_text: nil}
 
-      iex> Locations.new(%{altitude: 100.5, latitude: 37.7749, longitude: -122.4194})
-      %Locations{altitude: 100.5, latitude: 37.7749, longitude: -122.4194}
+      iex> Locations.new(%{altitude: 100.5, latitude: 37.7749, longitude: -122.4194, relevant_text: "Store nearby on 1st and Main"})
+      %Locations{altitude: 100.5, latitude: 37.7749, longitude: -122.4194, relevant_text: "Store nearby on 1st and Main"}
 
       iex> Locations.new(%{latitude: -50.75, longitude: 165.3})
-      %Locations{altitude: nil, latitude: -50.75, longitude: 165.3}
+      %Locations{altitude: nil, latitude: -50.75, longitude: 165.3, relevant_text: nil}
 
       iex> Locations.new(%{latitude: "invalid", longitude: 0.0})
       ** (ArgumentError) latitude must be a float
@@ -63,14 +66,19 @@ defmodule ExPass.Structs.Locations do
       iex> Locations.new(%{latitude: 37.7749, longitude: 181.0})
       ** (ArgumentError) longitude must be between -180 and 180
 
+      iex> Locations.new(%{latitude: 37.7749, longitude: -122.4194, relevant_text: 123})
+      ** (ArgumentError) relevant_text must be a string
+
   """
   @spec new(map()) :: %__MODULE__{}
   def new(attrs \\ %{}) do
     attrs =
       attrs
+      |> Converter.trim_string_values()
       |> validate(:altitude, &Validators.validate_optional_float(&1, :altitude))
       |> validate(:latitude, &Validators.validate_latitude(&1, :latitude))
       |> validate(:longitude, &Validators.validate_longitude(&1, :longitude))
+      |> validate(:relevant_text, &Validators.validate_optional_string(&1, :relevant_text))
 
     struct!(__MODULE__, attrs)
   end

--- a/test/structs/locations_test.exs
+++ b/test/structs/locations_test.exs
@@ -208,4 +208,54 @@ defmodule ExPass.Structs.LocationsTest do
       end
     end
   end
+
+  describe "relevantText" do
+    test "creates a valid Locations struct with relevantText" do
+      params = %{
+        latitude: 37.7749,
+        longitude: -122.4194,
+        relevant_text: "Store nearby on 1st and Main"
+      }
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.latitude == 37.7749
+      assert location.longitude == -122.4194
+      assert location.relevant_text == "Store nearby on 1st and Main"
+      encoded = Jason.encode!(location)
+      assert encoded =~ ~s("relevantText":"Store nearby on 1st and Main")
+    end
+
+    test "creates a valid Locations struct without relevantText" do
+      params = %{latitude: 37.7749, longitude: -122.4194}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.latitude == 37.7749
+      assert location.longitude == -122.4194
+      assert location.relevant_text == nil
+      encoded = Jason.encode!(location)
+      refute encoded =~ "relevantText"
+    end
+
+    test "trims whitespace from relevantText" do
+      params = %{latitude: 37.7749, longitude: -122.4194, relevant_text: "  Store nearby  "}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.relevant_text == "Store nearby"
+    end
+
+    test "returns error for non-string relevantText" do
+      params = %{latitude: 37.7749, longitude: -122.4194, relevant_text: 123}
+
+      assert_raise ArgumentError, "relevant_text must be a string if provided", fn ->
+        Locations.new(params)
+      end
+    end
+
+    test "allows empty string for relevantText" do
+      params = %{latitude: 37.7749, longitude: -122.4194, relevant_text: ""}
+
+      assert %Locations{} = location = Locations.new(params)
+      assert location.relevant_text == ""
+    end
+  end
 end


### PR DESCRIPTION
## Title

Add Optional `relevant_text` Field to Locations Struct for Contextual Messaging

## Type of Change

- [x] New feature
- [x] Documentation update

## Description

This pull request introduces a new optional field, `relevant_text`, to the `Locations` struct in the ExPass system. This field allows a descriptive message to be displayed when the pass is relevant, providing users with context such as information about a nearby store.

Validation ensures that `relevant_text`, if provided, is a valid string, and any extraneous whitespace is trimmed. The corresponding tests ensure that the field is correctly validated, trimmed, and serialized.

## Testing

New tests have been added to verify:
- Correct acceptance of valid strings for the `relevant_text` field.
- Trimming of leading and trailing whitespace from the field.
- Rejection of non-string values with appropriate error messages.
- JSON encoding of the `Locations` struct with and without the `relevant_text` field.

## Impact

This change is backward-compatible, as the `relevant_text` field is optional. It enhances the system by allowing location-specific messaging, which can improve the relevance of passes shown to users.

## Additional Information

No additional information is required.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

