### PR TITLE
114 add seat_type field for seat

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-****# ExPass
+# ExPass
 
 ExPass is an Elixir library for generating and manipulating Apple Wallet passes.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ExPass
+****# ExPass
 
 ExPass is an Elixir library for generating and manipulating Apple Wallet passes.
 
@@ -83,7 +83,7 @@ end
 |  | `Pass.semanticTags.seat.seatNumber` | [#111](https://github.com/njausteve/ex_pass/issues/111) | `todo` |
 |  | `Pass.semanticTags.seat.seatRow` | [#112](https://github.com/njausteve/ex_pass/issues/112) | `todo` |
 |  | `Pass.semanticTags.seat.seatSection` | [#113](https://github.com/njausteve/ex_pass/issues/113) | `todo` |
-|  | `Pass.semanticTags.seat.seatType` | [#114](https://github.com/njausteve/ex_pass/issues/114) | `todo` |
+|  | `Pass.semanticTags.seat.seatType` | [#114](https://github.com/njausteve/ex_pass/issues/114) | ✅ |
 | `Pass.Locations` | `Pass.locations.altitude` |  | `todo` |
 |  | `Pass.locations.latitude` |  | `todo` |
 |  | `Pass.locations.longitude` | [#90](https://github.com/njausteve/ex_pass/issues/90) | `todo` |

--- a/lib/structs/semantic_tags/seat.ex
+++ b/lib/structs/semantic_tags/seat.ex
@@ -1,0 +1,77 @@
+defmodule ExPass.Structs.SemanticTags.Seat do
+  @moduledoc """
+  Represents  the identification of a seat for a transit journey or an event.
+
+  ## Fields
+
+  * `:seat_type` - Optional. The type of seat, such as “Reserved seating”.
+
+  ## Compatibility
+
+  - iOS 12.0+
+  - iPadOS 6.0+
+  - watchOS 2.0+
+  """
+
+  use TypedStruct
+
+  alias ExPass.Utils.Converter
+  alias ExPass.Utils.Validators
+
+  typedstruct do
+    field :seat_type, String.t()
+  end
+
+  @doc """
+  Creates a new Seat struct.
+
+  ## Parameters
+
+    * `attrs` - A map of attributes for the Locations struct. The map can include the following keys:
+      * `:seat_type` - (Optional) The type of seat, such as “Reserved seating”.
+
+  ## Returns
+
+    * A new `%Seat{}` struct.
+
+  ## Examples
+
+      iex> Seat.new(%{seat_type: "Reserved seating"})
+      %Seat{seat_type: "Reserved seating"}
+
+      iex> Seat.new(%{seat_type: 123})
+      ** (ArgumentError) seat_type must be a string
+
+  """
+  @spec new(map()) :: %__MODULE__{}
+  def new(attrs \\ %{}) do
+    attrs =
+      attrs
+      |> Converter.trim_string_values()
+      |> validate(:seat_type, &Validators.validate_optional_string(&1, :seat_type))
+
+    struct!(__MODULE__, attrs)
+  end
+
+  defp validate(attrs, key, validator) do
+    case validator.(attrs[key]) do
+      :ok ->
+        attrs
+
+      {:error, reason} ->
+        raise ArgumentError, reason
+    end
+  end
+
+  defimpl Jason.Encoder do
+    def encode(seat, opts) do
+      seat
+      |> Map.from_struct()
+      |> Enum.reduce(%{}, fn
+        {_k, nil}, acc -> acc
+        {k, v}, acc -> Map.put(acc, Converter.camelize_key(k), v)
+      end)
+      |> Jason.Encode.map(opts)
+    end
+  end
+end

--- a/lib/structs/semantic_tags/seat.ex
+++ b/lib/structs/semantic_tags/seat.ex
@@ -27,7 +27,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
 
   ## Parameters
 
-    * `attrs` - A map of attributes for the Locations struct. The map can include the following keys:
+    * `attrs` - A map of attributes for the Seat struct. The map can include the following keys:
       * `:seat_type` - (Optional) The type of seat, such as “Reserved seating”.
 
   ## Returns

--- a/test/structs/semantic_tags/seat_test.exs
+++ b/test/structs/semantic_tags/seat_test.exs
@@ -1,0 +1,47 @@
+defmodule ExPass.Structs.SemanticTags.SeatTest do
+  @moduledoc false
+  use ExUnit.Case, async: true
+  alias ExPass.Structs.SemanticTags.Seat
+
+  describe "new/1 with seat_type" do
+    test "creates a valid Seat struct with seat_type" do
+      params = %{seat_type: "Reserved seating"}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_type == "Reserved seating"
+
+      encoded = Jason.encode!(seat)
+      assert encoded =~ ~s("seatType":"Reserved seating")
+    end
+
+    test "creates a valid Seat struct without seat_type" do
+      assert %Seat{} = seat = Seat.new(%{})
+      refute seat.seat_type
+
+      encoded = Jason.encode!(seat)
+      refute encoded =~ "seatType"
+    end
+
+    test "trims whitespace from seat_type" do
+      params = %{seat_type: "  Reserved seat  "}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_type == "Reserved seat"
+    end
+
+    test "returns error for non-string seat_type" do
+      params = %{seat_type: 123}
+
+      assert_raise ArgumentError, "seat_type must be a string if provided", fn ->
+        Seat.new(params)
+      end
+    end
+
+    test "allows empty string for seat_type" do
+      params = %{seat_type: ""}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_type == ""
+    end
+  end
+end

--- a/test/structs/semantic_tags/seat_test.exs
+++ b/test/structs/semantic_tags/seat_test.exs
@@ -3,6 +3,12 @@ defmodule ExPass.Structs.SemanticTags.SeatTest do
   use ExUnit.Case, async: true
   alias ExPass.Structs.SemanticTags.Seat
 
+  describe "new/0" do
+    test "creates an empty Seat struct" do
+      assert %Seat{} = Seat.new()
+    end
+  end
+
   describe "new/1 with seat_type" do
     test "creates a valid Seat struct with seat_type" do
       params = %{seat_type: "Reserved seating"}


### PR DESCRIPTION
## Title

Add optional `seat_type` field to Seat Struct for Semantic Tags.

## Type of Change

- [x] New feature
- [x] Documentation update

## Description

This pull request introduces a new `Seat` struct within the `ExPass` library to represent the identification of a seat for a transit journey or an event. The struct includes a `seat_type` field, which is optional and can be used to specify the type of seat, such as "Reserved seating". Additionally, tests have been added to ensure the correct functionality of the `Seat` struct, including validation and JSON encoding.

## Testing

The following tests have been added to verify the functionality of the `Seat` struct:
- Creation of a valid `Seat` struct with and without `seat_type`.
- Trimming of whitespace from `seat_type`.
- Validation to ensure `seat_type` is a string.
- Handling of empty string for `seat_type`.

## Impact

This change adds a new feature to the `ExPass` library, allowing for more detailed representation of seat information in Apple Wallet passes. It does not introduce any new dependencies or alter existing behavior outside of the new struct and its associated tests.

## Additional Information

The `Seat` struct is compatible with iOS 12.0+, iPadOS 6.0+, and watchOS 2.0+. The implementation includes a custom JSON encoder to handle the conversion of struct fields to camelCase.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
