### PR TITLE
95 add requiresauthentication field for nfc

### DIFF
--- a/lib/structs/nfc.ex
+++ b/lib/structs/nfc.ex
@@ -1,0 +1,73 @@
+defmodule ExPass.Structs.NFC do
+  @moduledoc """
+  Represents the near-field communication (NFC) payload the device passes to an Apple Pay terminal.
+
+  ## Fields
+
+  * `:requires_authentication` - (Optional) A Boolean value that indicates whether the NFC pass requires authentication.
+    When set to true, it requires the user to authenticate for each use of the NFC pass.
+    The default value is nil (not included in the pass).
+
+  ## Compatibility
+
+  - iOS 13.1+
+  - iPadOS 13.1+
+  - watchOS 2.0+
+  """
+
+  use ExPass.Structs.Base
+  use TypedStruct
+
+  alias ExPass.Utils.Validators
+
+  typedstruct do
+    field :requires_authentication, boolean(), default: nil
+  end
+
+  @doc """
+  Creates a new NFC struct.
+
+  ## Parameters
+
+    * `attrs` - A map of attributes for the NFC struct. The map can include the following keys:
+      * `:requires_authentication` - (Optional) A Boolean value that indicates whether the NFC pass requires authentication.
+        When set to true, it requires the user to authenticate for each use of the NFC pass.
+        The default value is nil (not included in the pass).
+
+  ## Returns
+
+    * A new `%NFC{}` struct.
+
+  ## Examples
+
+      iex> NFC.new()
+      %NFC{requires_authentication: nil}
+
+      iex> NFC.new(%{requires_authentication: true})
+      %NFC{requires_authentication: true}
+
+      iex> NFC.new(%{requires_authentication: false})
+      %NFC{requires_authentication: false}
+
+      iex> NFC.new(%{})
+      %NFC{requires_authentication: nil}
+
+      iex> NFC.new(%{requires_authentication: nil})
+      %NFC{requires_authentication: nil}
+
+      iex> NFC.new(%{requires_authentication: "true"})
+      ** (ArgumentError) requires_authentication must be a boolean value (true or false)
+
+  """
+  @spec new(map()) :: %__MODULE__{}
+  def new(attrs \\ %{}) do
+    attrs =
+      attrs
+      |> validate(
+        :requires_authentication,
+        &Validators.validate_boolean_field(&1, :requires_authentication)
+      )
+
+    struct!(__MODULE__, attrs)
+  end
+end

--- a/test/structs/nfc_test.exs
+++ b/test/structs/nfc_test.exs
@@ -8,57 +8,42 @@ defmodule ExPass.Structs.NFCTest do
 
   describe "new/0" do
     test "creates a valid NFC struct with default values when called without arguments" do
-      assert %NFC{} = nfc = NFC.new()
-      assert nfc.requires_authentication == nil
-      encoded = Jason.encode!(nfc)
-      refute encoded =~ "requiresAuthentication"
+      nfc = NFC.new()
+      assert %NFC{requires_authentication: nil} = nfc
+      refute Jason.encode!(nfc) =~ "requiresAuthentication"
     end
   end
 
   describe "new/1 with requiresAuthentication field" do
     test "creates a valid NFC struct with requiresAuthentication set to true" do
-      params = %{requires_authentication: true}
-
-      assert %NFC{} = nfc = NFC.new(params)
-      assert nfc.requires_authentication == true
-      encoded = Jason.encode!(nfc)
-      assert encoded =~ ~s("requiresAuthentication":true)
+      nfc = NFC.new(%{requires_authentication: true})
+      assert %NFC{requires_authentication: true} = nfc
+      assert Jason.encode!(nfc) =~ ~s("requiresAuthentication":true)
     end
 
     test "creates a valid NFC struct with requiresAuthentication set to false" do
-      params = %{requires_authentication: false}
-
-      assert %NFC{} = nfc = NFC.new(params)
-      assert nfc.requires_authentication == false
-      encoded = Jason.encode!(nfc)
-      assert encoded =~ ~s("requiresAuthentication":false)
+      nfc = NFC.new(%{requires_authentication: false})
+      assert %NFC{requires_authentication: false} = nfc
+      assert Jason.encode!(nfc) =~ ~s("requiresAuthentication":false)
     end
 
     test "creates a valid NFC struct with requiresAuthentication defaulting to nil when not provided" do
-      params = %{}
-
-      assert %NFC{} = nfc = NFC.new(params)
-      assert nfc.requires_authentication == nil
-      encoded = Jason.encode!(nfc)
-      refute encoded =~ "requiresAuthentication"
+      nfc = NFC.new(%{})
+      assert %NFC{requires_authentication: nil} = nfc
+      refute Jason.encode!(nfc) =~ "requiresAuthentication"
     end
 
     test "creates a valid NFC struct with requiresAuthentication set to nil" do
-      params = %{requires_authentication: nil}
-
-      assert %NFC{} = nfc = NFC.new(params)
-      assert nfc.requires_authentication == nil
-      encoded = Jason.encode!(nfc)
-      refute encoded =~ "requiresAuthentication"
+      nfc = NFC.new(%{requires_authentication: nil})
+      assert %NFC{requires_authentication: nil} = nfc
+      refute Jason.encode!(nfc) =~ "requiresAuthentication"
     end
 
     test "raises an error for invalid requiresAuthentication (non-boolean value)" do
-      params = %{requires_authentication: "true"}
-
       assert_raise ArgumentError,
                    "requires_authentication must be a boolean value (true or false)",
                    fn ->
-                     NFC.new(params)
+                     NFC.new(%{requires_authentication: "true"})
                    end
     end
   end

--- a/test/structs/nfc_test.exs
+++ b/test/structs/nfc_test.exs
@@ -1,0 +1,65 @@
+defmodule ExPass.Structs.NFCTest do
+  @moduledoc false
+
+  use ExUnit.Case, async: true
+  alias ExPass.Structs.NFC
+
+  doctest ExPass.Structs.NFC
+
+  describe "new/0" do
+    test "creates a valid NFC struct with default values when called without arguments" do
+      assert %NFC{} = nfc = NFC.new()
+      assert nfc.requires_authentication == nil
+      encoded = Jason.encode!(nfc)
+      refute encoded =~ "requiresAuthentication"
+    end
+  end
+
+  describe "new/1 with requiresAuthentication field" do
+    test "creates a valid NFC struct with requiresAuthentication set to true" do
+      params = %{requires_authentication: true}
+
+      assert %NFC{} = nfc = NFC.new(params)
+      assert nfc.requires_authentication == true
+      encoded = Jason.encode!(nfc)
+      assert encoded =~ ~s("requiresAuthentication":true)
+    end
+
+    test "creates a valid NFC struct with requiresAuthentication set to false" do
+      params = %{requires_authentication: false}
+
+      assert %NFC{} = nfc = NFC.new(params)
+      assert nfc.requires_authentication == false
+      encoded = Jason.encode!(nfc)
+      assert encoded =~ ~s("requiresAuthentication":false)
+    end
+
+    test "creates a valid NFC struct with requiresAuthentication defaulting to nil when not provided" do
+      params = %{}
+
+      assert %NFC{} = nfc = NFC.new(params)
+      assert nfc.requires_authentication == nil
+      encoded = Jason.encode!(nfc)
+      refute encoded =~ "requiresAuthentication"
+    end
+
+    test "creates a valid NFC struct with requiresAuthentication set to nil" do
+      params = %{requires_authentication: nil}
+
+      assert %NFC{} = nfc = NFC.new(params)
+      assert nfc.requires_authentication == nil
+      encoded = Jason.encode!(nfc)
+      refute encoded =~ "requiresAuthentication"
+    end
+
+    test "raises an error for invalid requiresAuthentication (non-boolean value)" do
+      params = %{requires_authentication: "true"}
+
+      assert_raise ArgumentError,
+                   "requires_authentication must be a boolean value (true or false)",
+                   fn ->
+                     NFC.new(params)
+                   end
+    end
+  end
+end


### PR DESCRIPTION
# Add NFC support with requiresAuthentication field

## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This PR adds support for the NFC (Near Field Communication) functionality in Apple Wallet passes by implementing the `requires_authentication` field. This field allows passes to require user authentication for each use of the NFC pass, enhancing security for sensitive NFC transactions.

The implementation follows Apple's documentation for the Pass.NFC object, specifically focusing on the `requiresAuthentication` property. As specified in the requirements, only this field has been implemented at this time, with other NFC fields to be added in future PRs.

Key changes:
- Created a new `ExPass.Structs.NFC` module with the `requires_authentication` field
- Implemented proper validation for boolean values
- Added comprehensive tests with 100% code coverage
- Ensured proper JSON encoding with camelCase field names

## Testing

The implementation follows a TDD approach with comprehensive test coverage:
- Added doctests for all use cases
- Created unit tests for all scenarios (true, false, nil, not provided)
- Added tests for error handling with invalid values
- Ensured 100% code coverage for the new module

All tests pass successfully, and the module maintains the project's 100% test coverage standard.

## Impact

This change enables support for NFC authentication in passes, which is particularly important for:
- Transit passes that require authentication
- Payment-related passes with security requirements
- Any pass where the user needs to authenticate before using NFC functionality

The implementation is backward compatible and follows the existing patterns in the codebase.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
