### PR TITLE
93 add encryptionpublickey field for nfc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ ex_pass-*.tar
 
 # Ignore Elixir Language Server files
 .elixir_ls/
+.qodo

--- a/lib/structs/nfc.ex
+++ b/lib/structs/nfc.ex
@@ -4,6 +4,8 @@ defmodule ExPass.Structs.NFC do
 
   ## Fields
 
+  * `:encryption_public_key` - (Required) The public encryption key the Value Added Services protocol uses.
+    Use a Base64-encoded X.509 SubjectPublicKeyInfo structure that contains an ECDH public key for group P256.
   * `:message` - (Required) The payload the device transmits to the Apple Pay terminal.
     The size needs to be no more than 64 bytes. The system truncates messages longer than 64 bytes.
   * `:requires_authentication` - (Optional) A Boolean value that indicates whether the NFC pass requires authentication.
@@ -21,8 +23,10 @@ defmodule ExPass.Structs.NFC do
   use TypedStruct
 
   alias ExPass.Utils.Validators
+  alias ExPass.Utils.PublicKey
 
   typedstruct do
+    field :encryption_public_key, String.t(), enforce: true
     field :message, String.t(), enforce: true
     field :requires_authentication, boolean(), default: nil
   end
@@ -33,6 +37,8 @@ defmodule ExPass.Structs.NFC do
   ## Parameters
 
     * `attrs` - A map of attributes for the NFC struct. The map can include the following keys:
+      * `:encryption_public_key` - (Required) The public encryption key the Value Added Services protocol uses.
+        Use a Base64-encoded X.509 SubjectPublicKeyInfo structure that contains an ECDH public key for group P256.
       * `:message` - (Required) The payload the device transmits to the Apple Pay terminal.
         The size needs to be no more than 64 bytes. The system truncates messages longer than 64 bytes.
       * `:requires_authentication` - (Optional) A Boolean value that indicates whether the NFC pass requires authentication.
@@ -45,17 +51,19 @@ defmodule ExPass.Structs.NFC do
 
   ## Examples
 
-      iex> NFC.new(%{message: "test message"})
-      %NFC{message: "test message", requires_authentication: nil}
+      iex> valid_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELUJ7jY8VfBkjJdHEiOZuX8sSYFTJ1sFR+VNgC2Vd5SYJx1x1F9QJD+hkXjE4wP4IaRyQF5s8zCPgKmXCuPGvdA=="
+      iex> NFC.new(%{message: "test message", encryption_public_key: valid_key})
+      %NFC{message: "test message", encryption_public_key: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELUJ7jY8VfBkjJdHEiOZuX8sSYFTJ1sFR+VNgC2Vd5SYJx1x1F9QJD+hkXjE4wP4IaRyQF5s8zCPgKmXCuPGvdA==", requires_authentication: nil}
 
-      iex> NFC.new(%{message: "test message", requires_authentication: true})
-      %NFC{message: "test message", requires_authentication: true}
+      iex> valid_key = "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELUJ7jY8VfBkjJdHEiOZuX8sSYFTJ1sFR+VNgC2Vd5SYJx1x1F9QJD+hkXjE4wP4IaRyQF5s8zCPgKmXCuPGvdA=="
+      iex> NFC.new(%{message: "test message", encryption_public_key: valid_key, requires_authentication: true})
+      %NFC{message: "test message", encryption_public_key: "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELUJ7jY8VfBkjJdHEiOZuX8sSYFTJ1sFR+VNgC2Vd5SYJx1x1F9QJD+hkXjE4wP4IaRyQF5s8zCPgKmXCuPGvdA==", requires_authentication: true}
 
       iex> NFC.new(%{})
       ** (ArgumentError) message is required
 
-      iex> NFC.new(%{message: String.duplicate("a", 65)})
-      ** (ArgumentError) message must be no more than 64 bytes
+      iex> NFC.new(%{message: "test message"})
+      ** (ArgumentError) encryption_public_key is required
 
   """
   @spec new(map()) :: %__MODULE__{}
@@ -63,6 +71,10 @@ defmodule ExPass.Structs.NFC do
     attrs =
       attrs
       |> validate(:message, &Validators.validate_message_length(&1, 64, :message))
+      |> validate(
+        :encryption_public_key,
+        &PublicKey.validate_encryption_public_key(&1, :encryption_public_key)
+      )
       |> validate(
         :requires_authentication,
         &Validators.validate_boolean_field(&1, :requires_authentication)

--- a/lib/utils/public_key.ex
+++ b/lib/utils/public_key.ex
@@ -1,0 +1,116 @@
+defmodule ExPass.Utils.PublicKey do
+  @moduledoc """
+  Provides validation functions for public key formats used in ExPass.
+
+  This module specifically handles validation of encryption public keys used in NFC
+  and other cryptographic contexts, ensuring they meet the required format and
+  structure specifications.
+  """
+
+  @ec_public_key_oid {1, 2, 840, 10_045, 2, 1}
+  @p256_curve_oid_binary <<6, 8, 42, 134, 72, 206, 61, 3, 1, 7>>
+
+  @uncompressed_key_header 0x04
+  # 1-byte header + 32-byte X coord + 32-byte Y coord
+  @compressed_key_headers [0x02, 0x03]
+  # 1-byte header + 32-byte compressed point
+  @uncompressed_key_size 65
+  @compressed_key_size 33
+
+  @doc """
+  Validates that a value is a Base64-encoded X.509 SubjectPublicKeyInfo structure
+  containing an ECDH public key for group P256.
+
+  ## Parameters
+    * `value` - The value to validate
+    * `field_name` - The name of the field being validated
+
+  ## Returns
+    * The original value if valid
+
+  ## Raises
+    * `ArgumentError` if the value is invalid
+
+  ## Examples
+
+      iex> validate_encryption_public_key("BASE64_ENCODED_VALID_KEY==", :encryption_public_key)
+      "BASE64_ENCODED_VALID_KEY=="
+
+      iex> validate_encryption_public_key(nil, :encryption_public_key)
+      ** (ArgumentError) encryption_public_key is required
+
+      iex> validate_encryption_public_key("invalid base64!", :encryption_public_key)
+      ** (ArgumentError) encryption_public_key must be a valid Base64 string
+
+  """
+  @spec validate_encryption_public_key(String.t() | nil, atom()) :: String.t()
+  def validate_encryption_public_key(nil, field_name),
+    do: raise(ArgumentError, "#{field_name} is required")
+
+  def validate_encryption_public_key(value, field_name) do
+    cond do
+      not is_binary(value) ->
+        raise ArgumentError, "#{field_name} must be a string"
+
+      String.trim(value) == "" ->
+        raise ArgumentError, "#{field_name} is required"
+
+      not base64?(value) ->
+        raise ArgumentError, "#{field_name} must be a valid Base64 string"
+
+      true ->
+        case validate_x509_spki_with_p256_ecdh(value, field_name) do
+          {:ok, _} -> value
+          {:error, reason} -> raise ArgumentError, "#{field_name} #{reason}"
+        end
+    end
+  end
+
+  defp base64?(str) do
+    case Base.decode64(str) do
+      {:ok, _decoded} -> true
+      :error -> false
+    end
+  end
+
+  defp validate_x509_spki_with_p256_ecdh(base64_str, _field_name) do
+    try do
+      {:ok, der} = Base.decode64(base64_str, padding: false)
+
+      case :public_key.der_decode(:SubjectPublicKeyInfo, der) do
+        {:SubjectPublicKeyInfo, algorithm, public_key} ->
+          cond do
+            not valid_ecdh_p256_algorithm?(algorithm) ->
+              {:error, "has an invalid algorithm. Expected ECDH P256 algorithm"}
+
+            not valid_ecdh_p256_key_format?(public_key) ->
+              {:error,
+               "has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point"}
+
+            true ->
+              {:ok, public_key}
+          end
+      end
+    rescue
+      _ ->
+        {:error, "is not a valid X.509 SubjectPublicKeyInfo structure"}
+    end
+  end
+
+  defp valid_ecdh_p256_algorithm?(algorithm) do
+    match?({:AlgorithmIdentifier, @ec_public_key_oid, @p256_curve_oid_binary}, algorithm)
+  end
+
+  defp valid_ecdh_p256_key_format?(public_key) do
+    case public_key do
+      <<@uncompressed_key_header, _::binary>> ->
+        byte_size(public_key) == @uncompressed_key_size
+
+      <<prefix::size(8), _::binary>> when prefix in @compressed_key_headers ->
+        byte_size(public_key) == @compressed_key_size
+
+      _ ->
+        false
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -16,7 +16,7 @@ defmodule ExPass.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger, :public_key]
     ]
   end
 

--- a/test/structs/nfc_test.exs
+++ b/test/structs/nfc_test.exs
@@ -4,6 +4,8 @@ defmodule ExPass.Structs.NFCTest do
   use ExUnit.Case, async: true
   alias ExPass.Structs.NFC
 
+  @valid_p256_key "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELUJ7jY8VfBkjJdHEiOZuX8sSYFTJ1sFR+VNgC2Vd5SYJx1x1F9QJD+hkXjE4wP4IaRyQF5s8zCPgKmXCuPGvdA=="
+
   doctest ExPass.Structs.NFC
 
   describe "new/0" do
@@ -14,75 +16,173 @@ defmodule ExPass.Structs.NFCTest do
     end
   end
 
-  describe "new/1 with message field" do
-    test "creates a valid NFC struct with message field" do
-      nfc = NFC.new(%{message: "test message"})
-      assert %NFC{message: "test message", requires_authentication: nil} = nfc
+  describe "new/1 with required fields" do
+    test "creates a valid NFC struct with required fields" do
+      params = %{
+        message: "test message",
+        encryption_public_key: @valid_p256_key
+      }
+
+      nfc = NFC.new(params)
+
+      assert %NFC{
+               message: "test message",
+               encryption_public_key: @valid_p256_key,
+               requires_authentication: nil
+             } = nfc
+
       encoded = Jason.encode!(nfc)
       assert encoded =~ ~s("message":"test message")
+      assert encoded =~ ~s("encryptionPublicKey":"#{@valid_p256_key}")
       refute encoded =~ "requiresAuthentication"
     end
 
     test "raises an error for missing message" do
       assert_raise ArgumentError, "message is required", fn ->
-        NFC.new(%{requires_authentication: true})
+        NFC.new(%{encryption_public_key: @valid_p256_key})
       end
     end
 
+    test "raises an error for missing encryption_public_key" do
+      assert_raise ArgumentError, "encryption_public_key is required", fn ->
+        NFC.new(%{message: "test message"})
+      end
+    end
+  end
+
+  describe "new/1 with message field" do
     test "raises an error for message exceeding 64 bytes" do
       long_message = String.duplicate("a", 65)
 
       assert_raise ArgumentError, "message must be no more than 64 bytes", fn ->
-        NFC.new(%{message: long_message})
+        NFC.new(%{
+          message: long_message,
+          encryption_public_key: @valid_p256_key
+        })
       end
     end
 
     test "raises an error for non-string message" do
       assert_raise ArgumentError, "message must be a string", fn ->
-        NFC.new(%{message: 123})
+        NFC.new(%{
+          message: 123,
+          encryption_public_key: @valid_p256_key
+        })
       end
     end
 
     test "accepts a message of exactly 64 bytes" do
       message_64_bytes = String.duplicate("a", 64)
 
-      nfc = NFC.new(%{message: message_64_bytes})
+      nfc =
+        NFC.new(%{
+          message: message_64_bytes,
+          encryption_public_key: @valid_p256_key
+        })
+
       assert %NFC{message: ^message_64_bytes} = nfc
       encoded = Jason.encode!(nfc)
       assert encoded =~ ~s("message":"#{message_64_bytes}")
     end
   end
 
+  describe "new/1 with encryption_public_key field" do
+    test "raises an error for non-string encryption_public_key" do
+      assert_raise ArgumentError, "encryption_public_key must be a string", fn ->
+        NFC.new(%{
+          message: "test message",
+          encryption_public_key: 123
+        })
+      end
+    end
+
+    test "raises an error for empty encryption_public_key" do
+      assert_raise ArgumentError, "encryption_public_key is required", fn ->
+        NFC.new(%{
+          message: "test message",
+          encryption_public_key: ""
+        })
+      end
+    end
+  end
+
   describe "new/1 with requiresAuthentication field" do
     test "creates a valid NFC struct with requiresAuthentication set to true" do
-      nfc = NFC.new(%{message: "test message", requires_authentication: true})
-      assert %NFC{message: "test message", requires_authentication: true} = nfc
+      nfc =
+        NFC.new(%{
+          message: "test message",
+          encryption_public_key: @valid_p256_key,
+          requires_authentication: true
+        })
+
+      assert %NFC{
+               message: "test message",
+               encryption_public_key: @valid_p256_key,
+               requires_authentication: true
+             } = nfc
+
       encoded = Jason.encode!(nfc)
       assert encoded =~ ~s("message":"test message")
+      assert encoded =~ ~s("encryptionPublicKey":"#{@valid_p256_key}")
       assert encoded =~ ~s("requiresAuthentication":true)
     end
 
     test "creates a valid NFC struct with requiresAuthentication set to false" do
-      nfc = NFC.new(%{message: "test message", requires_authentication: false})
-      assert %NFC{message: "test message", requires_authentication: false} = nfc
+      nfc =
+        NFC.new(%{
+          message: "test message",
+          encryption_public_key: @valid_p256_key,
+          requires_authentication: false
+        })
+
+      assert %NFC{
+               message: "test message",
+               encryption_public_key: @valid_p256_key,
+               requires_authentication: false
+             } = nfc
+
       encoded = Jason.encode!(nfc)
       assert encoded =~ ~s("message":"test message")
+      assert encoded =~ ~s("encryptionPublicKey":"#{@valid_p256_key}")
       assert encoded =~ ~s("requiresAuthentication":false)
     end
 
     test "creates a valid NFC struct with requiresAuthentication defaulting to nil when not provided" do
-      nfc = NFC.new(%{message: "test message"})
-      assert %NFC{message: "test message", requires_authentication: nil} = nfc
+      nfc =
+        NFC.new(%{
+          message: "test message",
+          encryption_public_key: @valid_p256_key
+        })
+
+      assert %NFC{
+               message: "test message",
+               encryption_public_key: @valid_p256_key,
+               requires_authentication: nil
+             } = nfc
+
       encoded = Jason.encode!(nfc)
       assert encoded =~ ~s("message":"test message")
+      assert encoded =~ ~s("encryptionPublicKey":"#{@valid_p256_key}")
       refute encoded =~ "requiresAuthentication"
     end
 
     test "creates a valid NFC struct with requiresAuthentication set to nil" do
-      nfc = NFC.new(%{message: "test message", requires_authentication: nil})
-      assert %NFC{message: "test message", requires_authentication: nil} = nfc
+      nfc =
+        NFC.new(%{
+          message: "test message",
+          encryption_public_key: @valid_p256_key,
+          requires_authentication: nil
+        })
+
+      assert %NFC{
+               message: "test message",
+               encryption_public_key: @valid_p256_key,
+               requires_authentication: nil
+             } = nfc
+
       encoded = Jason.encode!(nfc)
       assert encoded =~ ~s("message":"test message")
+      assert encoded =~ ~s("encryptionPublicKey":"#{@valid_p256_key}")
       refute encoded =~ "requiresAuthentication"
     end
 
@@ -90,7 +190,11 @@ defmodule ExPass.Structs.NFCTest do
       assert_raise ArgumentError,
                    "requires_authentication must be a boolean value (true or false)",
                    fn ->
-                     NFC.new(%{message: "test message", requires_authentication: "true"})
+                     NFC.new(%{
+                       message: "test message",
+                       encryption_public_key: @valid_p256_key,
+                       requires_authentication: "true"
+                     })
                    end
     end
   end

--- a/test/utils/public_key_test.exs
+++ b/test/utils/public_key_test.exs
@@ -19,110 +19,95 @@ defmodule ExPass.Utils.PublicKeyTest do
   @invalid_algorithm_key "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQAB"
 
   describe "validate_encryption_public_key/2" do
-    test "returns the value when it is a valid P256 ECDH public key" do
+    test "returns :ok when it is a valid P256 ECDH public key" do
       assert PublicKey.validate_encryption_public_key(@valid_p256_key, :encryption_public_key) ==
-               @valid_p256_key
+               :ok
     end
 
-    test "returns the value when it is a valid compressed P256 ECDH public key" do
+    test "returns :ok when it is a valid compressed P256 ECDH public key" do
       assert PublicKey.validate_encryption_public_key(
                @valid_compressed_key,
                :encryption_public_key
-             ) == @valid_compressed_key
+             ) == :ok
     end
 
-    test "raises ArgumentError when value is nil" do
-      assert_raise ArgumentError, "encryption_public_key is required", fn ->
-        PublicKey.validate_encryption_public_key(nil, :encryption_public_key)
-      end
+    test "returns error when value is nil" do
+      assert PublicKey.validate_encryption_public_key(nil, :encryption_public_key) ==
+               {:error, "encryption_public_key is required"}
     end
 
-    test "raises ArgumentError when value is not a string" do
-      assert_raise ArgumentError, "encryption_public_key must be a string", fn ->
-        PublicKey.validate_encryption_public_key(123, :encryption_public_key)
-      end
+    test "returns error when value is not a string" do
+      assert PublicKey.validate_encryption_public_key(123, :encryption_public_key) ==
+               {:error, "encryption_public_key must be a string"}
     end
 
-    test "raises ArgumentError when value is an empty string" do
-      assert_raise ArgumentError, "encryption_public_key is required", fn ->
-        PublicKey.validate_encryption_public_key("", :encryption_public_key)
-      end
+    test "returns error when value is an empty string" do
+      assert PublicKey.validate_encryption_public_key("", :encryption_public_key) ==
+               {:error, "encryption_public_key is required"}
     end
 
-    test "raises ArgumentError when value is a string with only whitespace" do
-      assert_raise ArgumentError, "encryption_public_key is required", fn ->
-        PublicKey.validate_encryption_public_key("   ", :encryption_public_key)
-      end
+    test "returns error when value is a string with only whitespace" do
+      assert PublicKey.validate_encryption_public_key("   ", :encryption_public_key) ==
+               {:error, "encryption_public_key is required"}
     end
 
-    test "raises ArgumentError when value is not a valid Base64 string" do
-      assert_raise ArgumentError, "encryption_public_key must be a valid Base64 string", fn ->
-        PublicKey.validate_encryption_public_key("not a base64 string!", :encryption_public_key)
-      end
+    test "returns error when value is not a valid Base64 string" do
+      assert PublicKey.validate_encryption_public_key(
+               "not a base64 string!",
+               :encryption_public_key
+             ) ==
+               {:error, "encryption_public_key must be a valid Base64 string"}
     end
 
-    test "raises ArgumentError when value is Base64 but not a valid X.509 SubjectPublicKeyInfo" do
+    test "returns error when value is Base64 but not a valid X.509 SubjectPublicKeyInfo" do
       # Valid Base64 but not a valid X.509 SubjectPublicKeyInfo
       invalid_base64 = Base.encode64("this is valid base64 but not a valid X.509 structure")
 
-      assert_raise ArgumentError,
-                   "encryption_public_key is not a valid X.509 SubjectPublicKeyInfo structure",
-                   fn ->
-                     PublicKey.validate_encryption_public_key(
-                       invalid_base64,
-                       :encryption_public_key
-                     )
-                   end
+      assert PublicKey.validate_encryption_public_key(invalid_base64, :encryption_public_key) ==
+               {:error,
+                "encryption_public_key is not a valid X.509 SubjectPublicKeyInfo structure"}
     end
 
-    test "raises ArgumentError with specific message when algorithm is invalid" do
-      assert_raise ArgumentError,
-                   "encryption_public_key has an invalid algorithm. Expected ECDH P256 algorithm",
-                   fn ->
-                     PublicKey.validate_encryption_public_key(
-                       @invalid_algorithm_key,
-                       :encryption_public_key
-                     )
-                   end
+    test "returns error with specific message when algorithm is invalid" do
+      assert PublicKey.validate_encryption_public_key(
+               @invalid_algorithm_key,
+               :encryption_public_key
+             ) ==
+               {:error,
+                "encryption_public_key has an invalid algorithm. Expected ECDH P256 algorithm"}
     end
 
-    test "raises ArgumentError with specific message when key format is invalid" do
-      assert_raise ArgumentError,
-                   "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point",
-                   fn ->
-                     PublicKey.validate_encryption_public_key(
-                       generate_invalid_key_format(),
-                       :encryption_public_key
-                     )
-                   end
+    test "returns error with specific message when key format is invalid" do
+      assert PublicKey.validate_encryption_public_key(
+               generate_invalid_key_format(),
+               :encryption_public_key
+             ) ==
+               {:error,
+                "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point"}
     end
 
     test "uses the provided field name in error messages" do
-      assert_raise ArgumentError, "custom_field is required", fn ->
-        PublicKey.validate_encryption_public_key(nil, :custom_field)
-      end
+      assert PublicKey.validate_encryption_public_key(nil, :custom_field) ==
+               {:error, "custom_field is required"}
 
-      assert_raise ArgumentError, "another_field must be a string", fn ->
-        PublicKey.validate_encryption_public_key(123, :another_field)
-      end
+      assert PublicKey.validate_encryption_public_key(123, :another_field) ==
+               {:error, "another_field must be a string"}
     end
 
-    test "raises ArgumentError when X.509 structure is decoded but not a SubjectPublicKeyInfo" do
+    test "returns error when X.509 structure is decoded but not a SubjectPublicKeyInfo" do
       # Create a valid DER-encoded sequence that's not a SubjectPublicKeyInfo
       simple_sequence = <<48, 10, 6, 3, 85, 4, 3, 12, 4, 116, 101, 115, 116>>
       simple_sequence_base64 = Base.encode64(simple_sequence)
 
-      assert_raise ArgumentError,
-                   "encryption_public_key is not a valid X.509 SubjectPublicKeyInfo structure",
-                   fn ->
-                     PublicKey.validate_encryption_public_key(
-                       simple_sequence_base64,
-                       :encryption_public_key
-                     )
-                   end
+      assert PublicKey.validate_encryption_public_key(
+               simple_sequence_base64,
+               :encryption_public_key
+             ) ==
+               {:error,
+                "encryption_public_key is not a valid X.509 SubjectPublicKeyInfo structure"}
     end
 
-    test "raises ArgumentError when compressed key has invalid size" do
+    test "returns error when compressed key has invalid size" do
       # First, we need to generate the SubjectPublicKeyInfo structure
       {:ok, der} = Base.decode64(@valid_compressed_key, padding: false)
       {:SubjectPublicKeyInfo, algorithm, _} = :public_key.der_decode(:SubjectPublicKeyInfo, der)
@@ -136,29 +121,30 @@ defmodule ExPass.Utils.PublicKeyTest do
       der = :public_key.der_encode(:SubjectPublicKeyInfo, spki)
       invalid_base64 = Base.encode64(der)
 
-      assert_raise ArgumentError, "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point", fn ->
-        PublicKey.validate_encryption_public_key(invalid_base64, :encryption_public_key)
-      end
+      assert PublicKey.validate_encryption_public_key(invalid_base64, :encryption_public_key) ==
+               {:error,
+                "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point"}
     end
 
-    test "raises ArgumentError when key has invalid header byte" do
+    test "returns error when key has invalid header byte" do
       # First, we need to generate the SubjectPublicKeyInfo structure
       {:ok, der} = Base.decode64(@valid_p256_key, padding: false)
       {:SubjectPublicKeyInfo, algorithm, _} = :public_key.der_decode(:SubjectPublicKeyInfo, der)
 
       # Create a key with an invalid header byte (not 0x04, 0x02, or 0x03)
       # Using 0x05 which isn't a valid EC point format
-      invalid_header_key = <<0x05, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
-                             16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32>>
+      invalid_header_key =
+        <<0x05, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23,
+          24, 25, 26, 27, 28, 29, 30, 31, 32>>
 
       # Re-encode with the same algorithm but invalid key format
       spki = {:SubjectPublicKeyInfo, algorithm, invalid_header_key}
       der = :public_key.der_encode(:SubjectPublicKeyInfo, spki)
       invalid_base64 = Base.encode64(der)
 
-      assert_raise ArgumentError, "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point", fn ->
-        PublicKey.validate_encryption_public_key(invalid_base64, :encryption_public_key)
-      end
+      assert PublicKey.validate_encryption_public_key(invalid_base64, :encryption_public_key) ==
+               {:error,
+                "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point"}
     end
   end
 

--- a/test/utils/public_key_test.exs
+++ b/test/utils/public_key_test.exs
@@ -1,0 +1,177 @@
+defmodule ExPass.Utils.PublicKeyTest do
+  @moduledoc """
+  Tests for the PublicKey utility module.
+
+  These tests verify the validation functions for public key formats used in ExPass,
+  particularly focusing on the validation of encryption public keys.
+  """
+
+  use ExUnit.Case, async: true
+  alias ExPass.Utils.PublicKey
+
+  # Sample valid P256 ECDH public key in SubjectPublicKeyInfo format (Base64 encoded)
+  @valid_p256_key "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELUJ7jY8VfBkjJdHEiOZuX8sSYFTJ1sFR+VNgC2Vd5SYJx1x1F9QJD+hkXjE4wP4IaRyQF5s8zCPgKmXCuPGvdA=="
+
+  # Sample valid compressed P256 ECDH public key in SubjectPublicKeyInfo format
+  @valid_compressed_key "MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAELUJ7jY8VfBkjJdHEiOZuX8sSYFTJ1sFR+VNgC2Vd5SYJx1x1F9QJD+hkXjE4wP4IaRyQF5s8zCPgKmXCuPGvdA=="
+
+  # Invalid algorithm key - this is a real SubjectPublicKeyInfo structure but with RSA algorithm instead of ECDH
+  @invalid_algorithm_key "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAu1SU1LfVLPHCozMxH2Mo4lgOEePzNm0tRgeLezV6ffAt0gunVTLw7onLRnrq0/IzW7yWR7QkrmBL7jTKEn5u+qKhbwKfBstIs+bMY2Zkp18gnTxKLxoS2tFczGkPLPgizskuemMghRniWaoLcyehkd3qqGElvW/VDL5AaWTg0nLVkjRo9z+40RQzuVaE8AkAFmxZzow3x+VJYKdjykkJ0iT9wCS0DRTXu269V264Vf/3jvredZiKRkgwlL9xNAwxXFg0x/XFw005UWVRIkdgcKWTjpBP2dPwVZ4WWC+9aGVd+Gyn1o0CLelf4rEjGoXbAAEgAqeGUxrcIlbjXfbcmwIDAQAB"
+
+  describe "validate_encryption_public_key/2" do
+    test "returns the value when it is a valid P256 ECDH public key" do
+      assert PublicKey.validate_encryption_public_key(@valid_p256_key, :encryption_public_key) ==
+               @valid_p256_key
+    end
+
+    test "returns the value when it is a valid compressed P256 ECDH public key" do
+      assert PublicKey.validate_encryption_public_key(
+               @valid_compressed_key,
+               :encryption_public_key
+             ) == @valid_compressed_key
+    end
+
+    test "raises ArgumentError when value is nil" do
+      assert_raise ArgumentError, "encryption_public_key is required", fn ->
+        PublicKey.validate_encryption_public_key(nil, :encryption_public_key)
+      end
+    end
+
+    test "raises ArgumentError when value is not a string" do
+      assert_raise ArgumentError, "encryption_public_key must be a string", fn ->
+        PublicKey.validate_encryption_public_key(123, :encryption_public_key)
+      end
+    end
+
+    test "raises ArgumentError when value is an empty string" do
+      assert_raise ArgumentError, "encryption_public_key is required", fn ->
+        PublicKey.validate_encryption_public_key("", :encryption_public_key)
+      end
+    end
+
+    test "raises ArgumentError when value is a string with only whitespace" do
+      assert_raise ArgumentError, "encryption_public_key is required", fn ->
+        PublicKey.validate_encryption_public_key("   ", :encryption_public_key)
+      end
+    end
+
+    test "raises ArgumentError when value is not a valid Base64 string" do
+      assert_raise ArgumentError, "encryption_public_key must be a valid Base64 string", fn ->
+        PublicKey.validate_encryption_public_key("not a base64 string!", :encryption_public_key)
+      end
+    end
+
+    test "raises ArgumentError when value is Base64 but not a valid X.509 SubjectPublicKeyInfo" do
+      # Valid Base64 but not a valid X.509 SubjectPublicKeyInfo
+      invalid_base64 = Base.encode64("this is valid base64 but not a valid X.509 structure")
+
+      assert_raise ArgumentError,
+                   "encryption_public_key is not a valid X.509 SubjectPublicKeyInfo structure",
+                   fn ->
+                     PublicKey.validate_encryption_public_key(
+                       invalid_base64,
+                       :encryption_public_key
+                     )
+                   end
+    end
+
+    test "raises ArgumentError with specific message when algorithm is invalid" do
+      assert_raise ArgumentError,
+                   "encryption_public_key has an invalid algorithm. Expected ECDH P256 algorithm",
+                   fn ->
+                     PublicKey.validate_encryption_public_key(
+                       @invalid_algorithm_key,
+                       :encryption_public_key
+                     )
+                   end
+    end
+
+    test "raises ArgumentError with specific message when key format is invalid" do
+      assert_raise ArgumentError,
+                   "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point",
+                   fn ->
+                     PublicKey.validate_encryption_public_key(
+                       generate_invalid_key_format(),
+                       :encryption_public_key
+                     )
+                   end
+    end
+
+    test "uses the provided field name in error messages" do
+      assert_raise ArgumentError, "custom_field is required", fn ->
+        PublicKey.validate_encryption_public_key(nil, :custom_field)
+      end
+
+      assert_raise ArgumentError, "another_field must be a string", fn ->
+        PublicKey.validate_encryption_public_key(123, :another_field)
+      end
+    end
+
+    test "raises ArgumentError when X.509 structure is decoded but not a SubjectPublicKeyInfo" do
+      # Create a valid DER-encoded sequence that's not a SubjectPublicKeyInfo
+      simple_sequence = <<48, 10, 6, 3, 85, 4, 3, 12, 4, 116, 101, 115, 116>>
+      simple_sequence_base64 = Base.encode64(simple_sequence)
+
+      assert_raise ArgumentError,
+                   "encryption_public_key is not a valid X.509 SubjectPublicKeyInfo structure",
+                   fn ->
+                     PublicKey.validate_encryption_public_key(
+                       simple_sequence_base64,
+                       :encryption_public_key
+                     )
+                   end
+    end
+
+    test "raises ArgumentError when compressed key has invalid size" do
+      # First, we need to generate the SubjectPublicKeyInfo structure
+      {:ok, der} = Base.decode64(@valid_compressed_key, padding: false)
+      {:SubjectPublicKeyInfo, algorithm, _} = :public_key.der_decode(:SubjectPublicKeyInfo, der)
+
+      # Create an invalid compressed key - use a valid header (0x02 or 0x03) but wrong size
+      # Should be 33 bytes but we'll make it shorter
+      invalid_compressed_key = <<0x02, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10>>
+
+      # Re-encode with the same algorithm but invalid key format
+      spki = {:SubjectPublicKeyInfo, algorithm, invalid_compressed_key}
+      der = :public_key.der_encode(:SubjectPublicKeyInfo, spki)
+      invalid_base64 = Base.encode64(der)
+
+      assert_raise ArgumentError, "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point", fn ->
+        PublicKey.validate_encryption_public_key(invalid_base64, :encryption_public_key)
+      end
+    end
+
+    test "raises ArgumentError when key has invalid header byte" do
+      # First, we need to generate the SubjectPublicKeyInfo structure
+      {:ok, der} = Base.decode64(@valid_p256_key, padding: false)
+      {:SubjectPublicKeyInfo, algorithm, _} = :public_key.der_decode(:SubjectPublicKeyInfo, der)
+
+      # Create a key with an invalid header byte (not 0x04, 0x02, or 0x03)
+      # Using 0x05 which isn't a valid EC point format
+      invalid_header_key = <<0x05, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15,
+                             16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32>>
+
+      # Re-encode with the same algorithm but invalid key format
+      spki = {:SubjectPublicKeyInfo, algorithm, invalid_header_key}
+      der = :public_key.der_encode(:SubjectPublicKeyInfo, spki)
+      invalid_base64 = Base.encode64(der)
+
+      assert_raise ArgumentError, "encryption_public_key has an invalid key format. Expected uncompressed (65 bytes) or compressed (33 bytes) EC point", fn ->
+        PublicKey.validate_encryption_public_key(invalid_base64, :encryption_public_key)
+      end
+    end
+  end
+
+  defp generate_invalid_key_format do
+    {:ok, der} = Base.decode64(@valid_p256_key, padding: false)
+    {:SubjectPublicKeyInfo, algorithm, _} = :public_key.der_decode(:SubjectPublicKeyInfo, der)
+
+    # Create an invalid public key with wrong size (just 10 bytes with uncompressed header)
+    invalid_key = <<0x04, 1, 2, 3, 4, 5, 6, 7, 8, 9>>
+
+    # Re-encode with the same algorithm but invalid key format
+    spki = {:SubjectPublicKeyInfo, algorithm, invalid_key}
+    der = :public_key.der_encode(:SubjectPublicKeyInfo, spki)
+    Base.encode64(der)
+  end
+end


### PR DESCRIPTION
## Type of Change

- [x] New feature

## Description

This PR adds support for the encryption public key field in NFC passes, which is required by the Value Added Services protocol. Key changes include:

1. Added a new required `encryption_public_key` field to the `NFC` struct
2. Created a new validation module `ExPass.Utils.PublicKey` to ensure the key is a valid Base64-encoded X.509 SubjectPublicKeyInfo structure containing an ECDH public key for group P256
3. Added `:public_key` to extra applications in `mix.exs` to support the cryptographic validation
4. Updated all tests to include the new required field and added tests specifically for the new field validation

These changes are necessary to comply with Apple's requirements for NFC passes that use the Value Added Services protocol, which requires a valid ECDH P256 public key.

## Testing

All existing tests have been updated to include the new required field, and new tests have been added to verify the validation logic for the encryption public key format. The test suite now includes:

- Validation of required fields
- Proper encoding in JSON
- Error handling for invalid key formats
- Test cases with a valid P256 key

## Impact

This is a breaking change for existing applications using the NFC struct, as they will need to provide the encryption public key when creating new NFC passes. However, this field is required by Apple, so this change ensures compliance with their specifications.

## Additional Information

The validation includes checking for both compressed and uncompressed EC point formats and validates against the correct OIDs for ECDH P256 curves.

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings