### PR TITLE
[109] Add seat description field for Seat struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ end
 | 59 | `todo` |  | `Pass.semanticTags.personNameComponents.nameSuffix` | [#105](https://github.com/njausteve/ex_pass/issues/105) |
 | 60 | `todo` |  | `Pass.semanticTags.personNameComponents.nickname` | [#106](https://github.com/njausteve/ex_pass/issues/106) |
 | 61 | `todo` |  | `Pass.semanticTags.personNameComponents.phoneticRepresentation` | [#107](https://github.com/njausteve/ex_pass/issues/107) |
-| 62 | `todo` | `Pass.SemanticTags.Seat` | `Pass.semanticTags.seat.seatDescription` | [#109](https://github.com/njausteve/ex_pass/issues/109) |
+| 62 | ✅ | `Pass.SemanticTags.Seat` | `Pass.semanticTags.seat.seatDescription` | [#109](https://github.com/njausteve/ex_pass/issues/109) |
 | 63 | `todo` |  | `Pass.semanticTags.seat.seatIdentifier` | [#110](https://github.com/njausteve/ex_pass/issues/110) |
 | 64 | `todo` |  | `Pass.semanticTags.seat.seatNumber` | [#111](https://github.com/njausteve/ex_pass/issues/111) |
 | 65 | `todo` |  | `Pass.semanticTags.seat.seatRow` | [#112](https://github.com/njausteve/ex_pass/issues/112) |

--- a/lib/structs/semantic_tags/seat.ex
+++ b/lib/structs/semantic_tags/seat.ex
@@ -21,6 +21,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
 
   typedstruct do
     field :seat_type, String.t()
+    field :seat_description, String.t()
   end
 
   @doc """
@@ -30,6 +31,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
 
     * `attrs` - A map of attributes for the Seat struct. The map can include the following keys:
       * `:seat_type` - (Optional) The type of seat, such as “Reserved seating”.
+      * `:seat_description` - (Optional) A description of the seat, such as “A flat bed seat“.
 
   ## Returns
 
@@ -37,11 +39,11 @@ defmodule ExPass.Structs.SemanticTags.Seat do
 
   ## Examples
 
-      iex> Seat.new(%{seat_type: "Reserved seating"})
-      %Seat{seat_type: "Reserved seating"}
+      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat"})
+      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat"}
 
       iex> Seat.new(%{seat_type: 123})
-      ** (ArgumentError) seat_type must be a string
+      ** (ArgumentError) seat_type must be a string if provided
 
   """
   @spec new(map()) :: %__MODULE__{}
@@ -50,6 +52,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
       attrs
       |> Converter.trim_string_values()
       |> validate(:seat_type, &Validators.validate_optional_string(&1, :seat_type))
+      |> validate(:seat_description, &Validators.validate_optional_string(&1, :seat_description))
 
     struct!(__MODULE__, attrs)
   end

--- a/test/structs/semantic_tags/seat_test.exs
+++ b/test/structs/semantic_tags/seat_test.exs
@@ -3,6 +3,8 @@ defmodule ExPass.Structs.SemanticTags.SeatTest do
   use ExUnit.Case, async: true
   alias ExPass.Structs.SemanticTags.Seat
 
+  doctest Seat
+
   describe "new/0" do
     test "creates an empty Seat struct" do
       assert %Seat{} = Seat.new()
@@ -48,6 +50,48 @@ defmodule ExPass.Structs.SemanticTags.SeatTest do
 
       assert %Seat{} = seat = Seat.new(params)
       assert seat.seat_type == ""
+    end
+  end
+
+  describe "new/1 with seat_description" do
+    test "creates a valid Seat struct with seat_description" do
+      params = %{seat_description: "Push back seat"}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_description == "Push back seat"
+
+      encoded = Jason.encode!(seat)
+      assert encoded =~ ~s("seatDescription":"Push back seat")
+    end
+
+    test "creates a valid Seat struct without seat_description" do
+      assert %Seat{} = seat = Seat.new(%{})
+      refute seat.seat_description
+
+      encoded = Jason.encode!(seat)
+      refute encoded =~ "seatDescription"
+    end
+
+    test "trims whitespace from seat_description" do
+      params = %{seat_description: "  Push back seat  "}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_description == "Push back seat"
+    end
+
+    test "returns error for non-string seat_description" do
+      params = %{seat_description: 123}
+
+      assert_raise ArgumentError, "seat_description must be a string if provided", fn ->
+        Seat.new(params)
+      end
+    end
+
+    test "allows empty string for seat_description" do
+      params = %{seat_description: ""}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_description == ""
     end
   end
 end


### PR DESCRIPTION
## Title
## Type of Change

- [x] New feature
- [ ] Bug fix
- [ ] Documentation update
- [ ] Refactoring
- [ ] Hotfix
- [ ] Security patch
- [ ] UI/UX improvement

## Description

This PR introduces a new optional field `seat_description` to the `Seat` struct within the `ExPass.Structs.SemanticTags.Seat` module. This field allows users to provide a descriptive text for a seat, such as "A flat bed seat" or "Push back seat".

#### Changes include:
- Adding the `seat_description` field to the `Seat` struct.
- Updating the `new/1` function to handle the new field with appropriate validation.
- Updating documentation and doctests to reflect the new field.
- Adding comprehensive tests to ensure correct behavior, including trimming whitespace, handling empty strings, and validating input types.

This addresses issue #109.

## Testing
Added unit tests covering:
- Creation of `Seat` struct with and without `seat_description`.
- JSON encoding verification.
- Whitespace trimming functionality.
- Validation of non-string inputs, ensuring appropriate errors are raised.
- Handling of empty strings.
- All tests pass successfully.

## Impact

- Adds additional flexibility and descriptive capability to the Seat struct.
- No breaking changes; the new field is optional.
- Minimal performance impact; validation and trimming operations are lightweight.

## Additional Information

None

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
