### PR TITLE
[110][111][112][113] Add additional seat-related fields to Seat struct

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,10 +80,10 @@ end
 | 60 | `todo` |  | `Pass.semanticTags.personNameComponents.nickname` | [#106](https://github.com/njausteve/ex_pass/issues/106) |
 | 61 | `todo` |  | `Pass.semanticTags.personNameComponents.phoneticRepresentation` | [#107](https://github.com/njausteve/ex_pass/issues/107) |
 | 62 | ✅ | `Pass.SemanticTags.Seat` | `Pass.semanticTags.seat.seatDescription` | [#109](https://github.com/njausteve/ex_pass/issues/109) |
-| 63 | `todo` |  | `Pass.semanticTags.seat.seatIdentifier` | [#110](https://github.com/njausteve/ex_pass/issues/110) |
-| 64 | `todo` |  | `Pass.semanticTags.seat.seatNumber` | [#111](https://github.com/njausteve/ex_pass/issues/111) |
-| 65 | `todo` |  | `Pass.semanticTags.seat.seatRow` | [#112](https://github.com/njausteve/ex_pass/issues/112) |
-| 66 | `todo` |  | `Pass.semanticTags.seat.seatSection` | [#113](https://github.com/njausteve/ex_pass/issues/113) |
+| 63 | ✅ |  | `Pass.semanticTags.seat.seatIdentifier` | [#110](https://github.com/njausteve/ex_pass/issues/110) |
+| 64 | ✅ |  | `Pass.semanticTags.seat.seatNumber` | [#111](https://github.com/njausteve/ex_pass/issues/111) |
+| 65 | ✅ |  | `Pass.semanticTags.seat.seatRow` | [#112](https://github.com/njausteve/ex_pass/issues/112) |
+| 66 | ✅ |  | `Pass.semanticTags.seat.seatSection` | [#113](https://github.com/njausteve/ex_pass/issues/113) |
 | 67 | `todo` | `Pass.SemanticTags.WifiNetwork` | `Pass.semanticTags.wifiNetwork.password` |  |
 | 68 | `todo` |  | `Pass.semanticTags.wifiNetwork.ssid` |  |
 | 69 | `todo` | `Pass.SemanticTags` | `Pass.semanticTags.airlineCode` | [#21](https://github.com/njausteve/ex_pass/issues/21) |

--- a/lib/structs/semantic_tags/seat.ex
+++ b/lib/structs/semantic_tags/seat.ex
@@ -8,6 +8,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
   * `:seat_description` - Optional. A description of the seat, such as “A flat bed seat“.
   * `:seat_identifier` - Optional. A unique identifier for the seat, such as “Aisle 12, Row 3, Seat 5”.
   * `:seat_number` - Optional. The number of the seat, such as “3A”.
+  * `:seat_row` - Optional. The row of the seat, such as “3”.
 
   ## Compatibility
 
@@ -27,6 +28,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
     field :seat_description, String.t()
     field :seat_identifier, String.t()
     field :seat_number, String.t()
+    field :seat_row, String.t()
   end
 
   @doc """
@@ -39,6 +41,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
       * `:seat_description` - (Optional) A description of the seat, such as “A flat bed seat“.
       * `:seat_identifier` - (Optional) A unique identifier for the seat, such as “Aisle 12, Row 3, Seat 5”.
       * `:seat_number` - (Optional) The number of the seat, such as “3A”.
+      * `:seat_row` - (Optional) The row of the seat, such as “3”.
 
   ## Returns
 
@@ -46,8 +49,8 @@ defmodule ExPass.Structs.SemanticTags.Seat do
 
   ## Examples
 
-      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E"})
-      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E"}
+      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E", seat_row: "3"})
+      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E", seat_row: "3"}
 
       iex> Seat.new(%{seat_type: 123})
       ** (ArgumentError) seat_type must be a string if provided
@@ -62,6 +65,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
       |> validate(:seat_description, &Validators.validate_optional_string(&1, :seat_description))
       |> validate(:seat_identifier, &Validators.validate_optional_string(&1, :seat_identifier))
       |> validate(:seat_number, &Validators.validate_optional_string(&1, :seat_number))
+      |> validate(:seat_row, &Validators.validate_optional_string(&1, :seat_row))
 
     struct!(__MODULE__, attrs)
   end

--- a/lib/structs/semantic_tags/seat.ex
+++ b/lib/structs/semantic_tags/seat.ex
@@ -9,6 +9,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
   * `:seat_identifier` - Optional. A unique identifier for the seat, such as “Aisle 12, Row 3, Seat 5”.
   * `:seat_number` - Optional. The number of the seat, such as “3A”.
   * `:seat_row` - Optional. The row of the seat, such as “3”.
+  * `:seat_section` - Optional. The section of the seat, such as “Aisle 12”.
 
   ## Compatibility
 
@@ -29,6 +30,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
     field :seat_identifier, String.t()
     field :seat_number, String.t()
     field :seat_row, String.t()
+    field :seat_section, String.t()
   end
 
   @doc """
@@ -42,6 +44,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
       * `:seat_identifier` - (Optional) A unique identifier for the seat, such as “Aisle 12, Row 3, Seat 5”.
       * `:seat_number` - (Optional) The number of the seat, such as “3A”.
       * `:seat_row` - (Optional) The row of the seat, such as “3”.
+      * `:seat_section` - (Optional) The section of the seat, such as “Aisle 12”.
 
   ## Returns
 
@@ -49,8 +52,8 @@ defmodule ExPass.Structs.SemanticTags.Seat do
 
   ## Examples
 
-      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E", seat_row: "3"})
-      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E", seat_row: "3"}
+      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E", seat_row: "3", seat_section: "Aisle 12"})
+      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E", seat_row: "3", seat_section: "Aisle 12"}
 
       iex> Seat.new(%{seat_type: 123})
       ** (ArgumentError) seat_type must be a string if provided
@@ -66,6 +69,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
       |> validate(:seat_identifier, &Validators.validate_optional_string(&1, :seat_identifier))
       |> validate(:seat_number, &Validators.validate_optional_string(&1, :seat_number))
       |> validate(:seat_row, &Validators.validate_optional_string(&1, :seat_row))
+      |> validate(:seat_section, &Validators.validate_optional_string(&1, :seat_section))
 
     struct!(__MODULE__, attrs)
   end

--- a/lib/structs/semantic_tags/seat.ex
+++ b/lib/structs/semantic_tags/seat.ex
@@ -5,6 +5,8 @@ defmodule ExPass.Structs.SemanticTags.Seat do
   ## Fields
 
   * `:seat_type` - Optional. The type of seat, such as “Reserved seating”.
+  * `:seat_description` - Optional. A description of the seat, such as “A flat bed seat“.
+  * `:seat_identifier` - Optional. A unique identifier for the seat, such as “Aisle 12, Row 3, Seat 5”.
 
   ## Compatibility
 
@@ -22,6 +24,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
   typedstruct do
     field :seat_type, String.t()
     field :seat_description, String.t()
+    field :seat_identifier, String.t()
   end
 
   @doc """
@@ -32,6 +35,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
     * `attrs` - A map of attributes for the Seat struct. The map can include the following keys:
       * `:seat_type` - (Optional) The type of seat, such as “Reserved seating”.
       * `:seat_description` - (Optional) A description of the seat, such as “A flat bed seat“.
+      * `:seat_identifier` - (Optional) A unique identifier for the seat, such as “Aisle 12, Row 3, Seat 5”.
 
   ## Returns
 
@@ -39,8 +43,8 @@ defmodule ExPass.Structs.SemanticTags.Seat do
 
   ## Examples
 
-      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat"})
-      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat"}
+      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5"})
+      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5"}
 
       iex> Seat.new(%{seat_type: 123})
       ** (ArgumentError) seat_type must be a string if provided
@@ -53,6 +57,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
       |> Converter.trim_string_values()
       |> validate(:seat_type, &Validators.validate_optional_string(&1, :seat_type))
       |> validate(:seat_description, &Validators.validate_optional_string(&1, :seat_description))
+      |> validate(:seat_identifier, &Validators.validate_optional_string(&1, :seat_identifier))
 
     struct!(__MODULE__, attrs)
   end

--- a/lib/structs/semantic_tags/seat.ex
+++ b/lib/structs/semantic_tags/seat.ex
@@ -7,6 +7,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
   * `:seat_type` - Optional. The type of seat, such as “Reserved seating”.
   * `:seat_description` - Optional. A description of the seat, such as “A flat bed seat“.
   * `:seat_identifier` - Optional. A unique identifier for the seat, such as “Aisle 12, Row 3, Seat 5”.
+  * `:seat_number` - Optional. The number of the seat, such as “3A”.
 
   ## Compatibility
 
@@ -25,6 +26,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
     field :seat_type, String.t()
     field :seat_description, String.t()
     field :seat_identifier, String.t()
+    field :seat_number, String.t()
   end
 
   @doc """
@@ -36,6 +38,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
       * `:seat_type` - (Optional) The type of seat, such as “Reserved seating”.
       * `:seat_description` - (Optional) A description of the seat, such as “A flat bed seat“.
       * `:seat_identifier` - (Optional) A unique identifier for the seat, such as “Aisle 12, Row 3, Seat 5”.
+      * `:seat_number` - (Optional) The number of the seat, such as “3A”.
 
   ## Returns
 
@@ -43,8 +46,8 @@ defmodule ExPass.Structs.SemanticTags.Seat do
 
   ## Examples
 
-      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5"})
-      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5"}
+      iex> Seat.new(%{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E"})
+      %Seat{seat_type: "Reserved seating", seat_description: "A push back seat", seat_identifier: "Aisle 12, Row 3, Seat 5", seat_number: "3E"}
 
       iex> Seat.new(%{seat_type: 123})
       ** (ArgumentError) seat_type must be a string if provided
@@ -58,6 +61,7 @@ defmodule ExPass.Structs.SemanticTags.Seat do
       |> validate(:seat_type, &Validators.validate_optional_string(&1, :seat_type))
       |> validate(:seat_description, &Validators.validate_optional_string(&1, :seat_description))
       |> validate(:seat_identifier, &Validators.validate_optional_string(&1, :seat_identifier))
+      |> validate(:seat_number, &Validators.validate_optional_string(&1, :seat_number))
 
     struct!(__MODULE__, attrs)
   end

--- a/test/structs/semantic_tags/seat_test.exs
+++ b/test/structs/semantic_tags/seat_test.exs
@@ -94,4 +94,46 @@ defmodule ExPass.Structs.SemanticTags.SeatTest do
       assert seat.seat_description == ""
     end
   end
+
+  describe "new/1 with seat_identifier" do
+    test "creates a valid Seat struct with seat_identifier" do
+      params = %{seat_identifier: "Aisle 12, Row 3, Seat 5"}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_identifier == "Aisle 12, Row 3, Seat 5"
+
+      encoded = Jason.encode!(seat)
+      assert encoded =~ ~s("seatIdentifier":"Aisle 12, Row 3, Seat 5")
+    end
+
+    test "creates a valid Seat struct without seat_identifier" do
+      assert %Seat{} = seat = Seat.new(%{})
+      refute seat.seat_identifier
+
+      encoded = Jason.encode!(seat)
+      refute encoded =~ "seatIdentifier"
+    end
+
+    test "trims whitespace from seat_identifier" do
+      params = %{seat_identifier: "  Aisle 12, Row 3, Seat 5  "}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_identifier == "Aisle 12, Row 3, Seat 5"
+    end
+
+    test "returns error for non-string seat_identifier" do
+      params = %{seat_identifier: 123}
+
+      assert_raise ArgumentError, "seat_identifier must be a string if provided", fn ->
+        Seat.new(params)
+      end
+    end
+
+    test "allows empty string for seat_identifier" do
+      params = %{seat_identifier: ""}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_identifier == ""
+    end
+  end
 end

--- a/test/structs/semantic_tags/seat_test.exs
+++ b/test/structs/semantic_tags/seat_test.exs
@@ -178,4 +178,46 @@ defmodule ExPass.Structs.SemanticTags.SeatTest do
       assert seat.seat_number == ""
     end
   end
+
+  describe "new/1 with seat_row" do
+    test "creates a valid Seat struct with seat_row" do
+      params = %{seat_row: "3"}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_row == "3"
+
+      encoded = Jason.encode!(seat)
+      assert encoded =~ ~s("seatRow":"3")
+    end
+
+    test "creates a valid Seat struct without seat_row" do
+      assert %Seat{} = seat = Seat.new(%{})
+      refute seat.seat_row
+
+      encoded = Jason.encode!(seat)
+      refute encoded =~ "seatRow"
+    end
+
+    test "trims whitespace from seat_row" do
+      params = %{seat_row: "  3  "}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_row == "3"
+    end
+
+    test "returns error for non-string seat_row" do
+      params = %{seat_row: 123}
+
+      assert_raise ArgumentError, "seat_row must be a string if provided", fn ->
+        Seat.new(params)
+      end
+    end
+
+    test "allows empty string for seat_row" do
+      params = %{seat_row: ""}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_row == ""
+    end
+  end
 end

--- a/test/structs/semantic_tags/seat_test.exs
+++ b/test/structs/semantic_tags/seat_test.exs
@@ -220,4 +220,46 @@ defmodule ExPass.Structs.SemanticTags.SeatTest do
       assert seat.seat_row == ""
     end
   end
+
+  describe "new/1 with seat_section" do
+    test "creates a valid Seat struct with seat_section" do
+      params = %{seat_section: "Aisle 12"}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_section == "Aisle 12"
+
+      encoded = Jason.encode!(seat)
+      assert encoded =~ ~s("seatSection":"Aisle 12")
+    end
+
+    test "creates a valid Seat struct without seat_section" do
+      assert %Seat{} = seat = Seat.new(%{})
+      refute seat.seat_section
+
+      encoded = Jason.encode!(seat)
+      refute encoded =~ "seat_section"
+    end
+
+    test "trims whitespace from seat_section" do
+      params = %{seat_section: "  Aisle 12  "}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_section == "Aisle 12"
+    end
+
+    test "returns error for non-string seat_section" do
+      params = %{seat_section: 123}
+
+      assert_raise ArgumentError, "seat_section must be a string if provided", fn ->
+        Seat.new(params)
+      end
+    end
+
+    test "allows empty string for seat_section" do
+      params = %{seat_section: ""}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_section == ""
+    end
+  end
 end

--- a/test/structs/semantic_tags/seat_test.exs
+++ b/test/structs/semantic_tags/seat_test.exs
@@ -136,4 +136,46 @@ defmodule ExPass.Structs.SemanticTags.SeatTest do
       assert seat.seat_identifier == ""
     end
   end
+
+  describe "new/1 with seat_number" do
+    test "creates a valid Seat struct with seat_number" do
+      params = %{seat_number: "3E"}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_number == "3E"
+
+      encoded = Jason.encode!(seat)
+      assert encoded =~ ~s("seatNumber":"3E")
+    end
+
+    test "creates a valid Seat struct without seat_number" do
+      assert %Seat{} = seat = Seat.new(%{})
+      refute seat.seat_number
+
+      encoded = Jason.encode!(seat)
+      refute encoded =~ "seatNumber"
+    end
+
+    test "trims whitespace from seat_number" do
+      params = %{seat_number: "  3E  "}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_number == "3E"
+    end
+
+    test "returns error for non-string seat_number" do
+      params = %{seat_number: 123}
+
+      assert_raise ArgumentError, "seat_number must be a string if provided", fn ->
+        Seat.new(params)
+      end
+    end
+
+    test "allows empty string for seat_number" do
+      params = %{seat_number: ""}
+
+      assert %Seat{} = seat = Seat.new(params)
+      assert seat.seat_number == ""
+    end
+  end
 end


### PR DESCRIPTION
## Title

[Provide a succinct and descriptive title for the pull request, e.g., "Improve caching mechanism for API calls"]

## Type of Change

- [x] New feature

## Description

This PR expands the `Seat` struct in the `ExPass.Structs.SemanticTags.Seat` module by adding several optional fields:
- `seat_identifier`: A unique identifier for the seat (e.g., "Aisle 12, Row 3, Seat 5").
- `seat_number`: The seat number (e.g., "3A").
- `seat_row`: The row of the seat (e.g., "3").
- `seat_section`: The section of the seat (e.g., "Aisle 12").

#### Changes include:
- Updating the struct definition to include the new fields.
- Extending the `new/1` function to handle these fields with proper validation.
- Updating documentation and doctests to reflect the new fields.
- Adding comprehensive tests for each new field, covering creation, validation, whitespace trimming, JSON encoding, and handling of empty strings.

This addresses the following issues:
- #110 
- #111 
- #112 
- #113 

## Testing

Added extensive unit tests covering:
- Creation of Seat struct with and without each new field.
- JSON encoding verification for each new field.
- Whitespace trimming functionality for each new field.
- Validation of non-string inputs, ensuring appropriate errors are raised.
- Handling of empty strings for each new field.

All tests pass successfully.

## Impact

- Enhances the descriptive capabilities of the Seat struct.
- No breaking changes; all new fields are optional.
- Minimal performance impact due to lightweight validation and trimming operations.

## Additional Information

None

## Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings
